### PR TITLE
Fix bug in 'convert_size_to_bytes' function for non-integer inputs

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1364,7 +1364,7 @@ def convert_size_to_bytes(size):
     except ValueError:
         units = str(size)[-1].upper()
         p = "KMGTP".index(units) + 1
-        return int(float(str(size)[:-1])) * int(math.pow(1024,p))
+        return int(float(str(size)[:-1]) * math.pow(1024,p))
 
 def format_size(size,units='K',human_readable=False):
     """

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -2838,6 +2838,7 @@ class TestConvertSizeToBytes(unittest.TestCase):
         self.assertEqual(convert_size_to_bytes('4.0M'),4194304)
         self.assertEqual(convert_size_to_bytes('4.0G'),4294967296)
         self.assertEqual(convert_size_to_bytes('4.0T'),4398046511104)
+        self.assertEqual(convert_size_to_bytes('4.5G'),4831838208)
         self.assertEqual(convert_size_to_bytes('4T'),4398046511104)
 
 class TestFormatSize(unittest.TestCase):


### PR DESCRIPTION
Fixes a bug in the 'convert_size_to_bytes' function when non-integer inputs (e.g. `4.5G`) are supplied. In these cases the floating point value (`4.5`) was being converted to an integer (`4`) before being scaled by the appropriate units.

The fix preserves the floating point value for the scaling and only converts to integer (bytes) at the end.