### PR TITLE
Implement functionality to locate the largest file in a directory

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -192,6 +192,22 @@ class Directory:
                 yield o
 
     @property
+    def largest_file(self):
+        """
+        Return size and path of largest file
+
+        Returns a tuple of (relpath,size)
+        """
+        max_size = 0
+        largest = None
+        for o in self.walk():
+            s = self.getsize((o,))
+            if s > max_size:
+                max_size = s
+                largest = os.path.relpath(o,self._path)
+        return (largest,max_size)
+
+    @property
     def unknown_uids(self):
         """
         Return paths that have unrecognised UIDs

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -145,6 +145,7 @@ class TestDirectory(unittest.TestCase):
         self.assertEqual(d.basename,"example")
         self.assertEqual(d.parent_dir,self.wd)
         self.assertEqual(d.size,8192)
+        self.assertEqual(d.largest_file,("ex1.txt",4096))
         self.assertEqual(list(d.compressed_files),[])
         self.assertEqual(list(d.unknown_uids),[])
         self.assertFalse(d.has_unknown_uids)


### PR DESCRIPTION
Implements a new function/property on the `Directory` class (in the `archive` module) called `largest_file`, which locates the biggest file and returns the file path and size.