### PR TITLE
Update pre-flight checks for the "archive" command

### DIFF
--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -99,8 +99,9 @@ def main(argv=None):
                                 help="check for and warn about potential "
                                 "issues; don't perform archiving")
     parser_archive.add_argument('--force',action='store_true',
-                                help="ignore problems about unreadable "
-                                "files and external symlinks")
+                                help="ignore issues and perform "
+                                "archiving anyway (may result in "
+                                "incomplete or problematic archive)")
 
     # 'verify' command
     parser_verify = s.add_parser('verify',


### PR DESCRIPTION
Updates the command line interface for the `archive` command, to add new pre-flight checks:

* Check volume size exceeds size of largest file in the source directory (if multi-volume archiving is requested)
* Check destination archive directory doesn't already exist

Also modify the behaviour (including the above) so that any failing check now prevents the archiving from being attempted. This can be overridden by the `--force` option (except for an existing destination archive, which will always fail).