### PR TITLE
Nicer handling of errors from CLI when input run directory doesn't exist

### DIFF
--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -404,7 +404,7 @@ def main(argv=None):
     if args.subcommand == 'compare':
         try:
             d1 = get_rundir_instance(args.dir1)
-        except Excepion as ex:
+        except Exception as ex:
             logger.error(ex)
             return CLIStatus.ERROR
         print("Comparing %s against %s" % (d1,args.dir2))


### PR DESCRIPTION
Improves the reporting of errors/exceptions raised when attempting to load run directories which don't actually exist in the `info`, `archive` and `compare` commands.