### PR TITLE
Fix error with 'follow_symlinks' argument of 'os.lstat' when writing manifest file

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1409,12 +1409,12 @@ def make_manifest_file(d, manifest_file):
                 owner = Path(o).owner()
             except (KeyError,FileNotFoundError):
                 # Unknown user, fall back to UID
-                owner = os.lstat(o,follow_symlinks=False).st_uid
+                owner = os.stat(o,follow_symlinks=False).st_uid
             try:
                 group = Path(o).group()
             except (KeyError,FileNotFoundError):
                 # Unknown group, fall back to GID
-                group = os.lstat(o,follow_symlinks=False).st_gid
+                group = os.stat(o,follow_symlinks=False).st_gid
             fp.write("{owner}\t{group}\t{obj}\n".format(
                 owner=owner,
                 group=group,


### PR DESCRIPTION
It appears that `os.lstat` doesn't support the `follow_symlink` argument on some (older?) versions of Python, causing the `make_manifest_file` function to fail. Switching to `os.stat` seems to fix the issue.