### PR TITLE
Fix the 'is_dirlink' and 'is_broken_symlink' methods of Paths for symlinks to inaccessible files

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -122,7 +122,12 @@ class Path(type(pathlib.Path())):
         Returns True if Path is a symbolic link to a directory
         """
         if self.is_symlink() and not self.is_unresolvable_symlink():
-            return self.resolve().is_dir()
+            try:
+                return self.resolve().is_dir()
+            except PermissionError:
+                # Don't have permission to check
+                # i.e. essentially broken symlink
+                return False
         return False
 
     def is_broken_symlink(self):
@@ -130,12 +135,17 @@ class Path(type(pathlib.Path())):
         Returns True if Path is a symbolic link with non-existent target
         """
         if self.is_symlink() and not self.is_unresolvable_symlink():
-            return not self.resolve().exists()
+            try:
+                return not self.resolve().exists()
+            except PermissionError:
+                # Don't have permission to check
+                # i.e. essentially broken symlink
+                return True
         return False
 
     def is_unresolvable_symlink(self):
         """
-        Returns True if Path is a symbolic link that resolves to itself
+        Returns True if Path is a symbolic link that cannot be resolved
         """
         if self.is_symlink():
             try:

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -260,6 +260,35 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
 
+    def test_path_is_symlink_to_inaccessible_file(self):
+        """
+        Path: check symlink to inaccessible file
+        """
+        # "Inaccessible file" is a file under a directory
+        # which is not readable by the current user
+        d = os.path.join(self.wd, "dir")
+        os.makedirs(d)
+        f = os.path.join(d, "file")
+        with open(f, "wt") as fp:
+            fp.write("some content")
+        s = os.path.join(self.wd, "symlink")
+        os.symlink(f, s)
+        self.assertTrue(Path(s).is_symlink())
+        self.assertFalse(Path(s).is_broken_symlink())
+        self.assertFalse(Path(s).is_hardlink())
+        self.assertFalse(Path(s).is_dirlink())
+        self.assertFalse(Path(s).is_unresolvable_symlink())
+        # Make subdirectory unreadable
+        try:
+            os.chmod(d, 0o000)
+            self.assertTrue(Path(s).is_symlink())
+            self.assertTrue(Path(s).is_broken_symlink())
+            self.assertFalse(Path(s).is_hardlink())
+            self.assertFalse(Path(s).is_dirlink())
+            self.assertFalse(Path(s).is_unresolvable_symlink())
+        finally:
+            os.chmod(d, 0o777)
+
     def test_path_owner(self):
         """
         Path: check 'owner' works for different cases


### PR DESCRIPTION
Fixes the `is_dirlink` and `is_broken_symlink` methods of the `Path` class to handle symbolic links to inaccessible files i.e. files where a parent directory component is not readable by the current user (even if the full path to the file exists on the file system).

For example:

* The file `/home/user1/for_my_eyes_only.txt` exists but the directory `/home/user1` only allows read by user1
* Elsewhere user1 creates a symlink (e.g. `/public/for_user1s_eyes_only.txt`) to this file in a directory that is readable by all users
* user1 can access the symlink contents (e.g. `cat /public/for_user1s_eyes_only.txt` shows the contents), but other users will get `Permission denied`

Symlinks to inaccessible files are treated as broken symlinks within the archiver.