### PR TITLE
Add header line to archive directory manifest files

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1986,6 +1986,7 @@ def make_manifest_file(d, manifest_file, follow_dirlinks=False):
     if Path(manifest_file).exists():
         raise NgsArchiverException(f"{manifest_file}: already exists")
     with open(manifest_file, 'wt') as fp:
+        fp.write("#Owner\tGroup\tPath\n")
         for o in d.walk(followlinks=follow_dirlinks):
             o = Path(o)
             owner = Path(o).owner()

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -5934,7 +5934,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt"]
         with open(manifest_file, 'rt') as fp:
@@ -5961,7 +5962,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt",
                           f"{username}\t{group}\tsubdir/symlink1.txt"]
@@ -5989,7 +5991,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt",
                           f"{username}\t{group}\tsubdir/symlink1.txt"]
@@ -6018,7 +6021,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt",
                           f"{username}\t{group}\tsubdir/symlink1.txt"]
@@ -6046,7 +6050,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt",
                           f"{username}\t{group}\tsubdir2"]
@@ -6067,7 +6072,8 @@ class TestMakeManifestFile(unittest.TestCase):
         self.assertEqual(manifest_file, os.path.join(self.wd, "manifest2"))
         self.assertTrue(os.path.exists(manifest_file))
         # Check contents
-        expected_lines = [f"{username}\t{group}\tex1.txt",
+        expected_lines = ["#Owner\tGroup\tPath",
+                          f"{username}\t{group}\tex1.txt",
                           f"{username}\t{group}\tsubdir",
                           f"{username}\t{group}\tsubdir/ex2.txt",
                           f"{username}\t{group}\tsubdir2",


### PR DESCRIPTION
Adds a header line to the `manifest` metadata files created for compressed and copy archive directories, of the form:

    #Owner    Group    Path

This is intended to make it easier to understand what the file contents are.