### PR TITLE
Add "source date" to archiver metadata in archive directories

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -17,6 +17,7 @@ import math
 import stat
 import json
 import time
+import datetime
 import pwd
 import grp
 import time
@@ -42,6 +43,7 @@ logging.basicConfig(level="INFO",format='%(levelname)s: %(message)s')
 #######################################################################
 
 MD5_BLOCKSIZE = 1024*1024
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 #######################################################################
 # Classes
@@ -1512,6 +1514,7 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     archive_metadata = {
         'name': d.basename,
         'source': d.path,
+        'source_date': None,
         'type': ArchiveDirectory.__name__,
         'subarchives': [],
         'files': [],
@@ -1522,6 +1525,10 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
         'compression_level': compresslevel,
         'ngsarchiver_version': get_version(),
     }
+    # Set the source date
+    source_timestamp = os.path.getmtime(d.path)
+    archive_metadata["source_date"] = datetime.datetime.fromtimestamp(
+        source_timestamp).strftime(DATE_FORMAT)
     # Get list of unreadable objects that can't be archived
     # These will be excluded from the archive dir
     unreadable = list(d.unreadable_files)
@@ -2095,12 +2102,15 @@ def make_copy(d, dest, replace_symlinks=False,
             fp.write(f"{md5}  {o.relative_to(d.path)}\n")
     print(f"- created checksums file '{md5sums}'")
     # Add JSON file with archiver info
+    source_timestamp = os.path.getmtime(d.path)
     archive_metadata = {
         'name': d.basename,
         'source': d.path,
+        'source_date': datetime.datetime.fromtimestamp(
+            source_timestamp).strftime(DATE_FORMAT),
         'type': CopyArchiveDirectory.__name__,
         'user': getpass.getuser(),
-        'creation_date': time.strftime("%Y-%m-%d %H:%M:%S"),
+        'creation_date': time.strftime(DATE_FORMAT),
         'replace_symlinks': format_bool(replace_symlinks),
         'transform_broken_symlinks': format_bool(transform_broken_symlinks),
         'follow_dirlinks': format_bool(follow_dirlinks),

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1656,7 +1656,7 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
             fp.write("%s  %s\n" % (md5sum(os.path.join(temp_archive_dir,f)),
                                    f))
     # Update the creation date
-    archive_metadata['creation_date'] = time.strftime("%Y-%m-%d %H:%M:%S")
+    archive_metadata['creation_date'] = time.strftime(DATE_FORMAT)
     # Write archive contents to JSON file
     json_file = os.path.join(ngsarchiver_dir, "archiver_metadata.json")
     with open(json_file,'wt') as fp:

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -1376,6 +1376,7 @@ d1ee10b76e42d7e06921e41fbb9b75f7  example/subdir3/ex1.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "example.tar.gz"
@@ -1497,6 +1498,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "subdir1.tar.gz",
@@ -1626,6 +1628,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "subdir1.tar.gz",
@@ -1767,6 +1770,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "example.00.tar.gz",
@@ -1923,6 +1927,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "subdir1.00.tar.gz",
@@ -2108,6 +2113,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "subdir1.00.tar.gz",
@@ -2233,6 +2239,7 @@ a03dcb0295d903ee194ccb117b41f870  example_external_symlinks/subdir3/ex2.txt
                             content="""{
   "name": "example_external_symlinks",
   "source": "/original/path/to/example_external_symlinks",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "example_external_symlinks.tar.gz"
@@ -2388,6 +2395,7 @@ a03dcb0295d903ee194ccb117b41f870  example_broken_symlinks/subdir3/ex2.txt
                             content="""{
   "name": "example_broken_symlinks",
   "source": "/original/path/to/example_broken_symlinks",
+  "source_date": "2019-11-27 17:19:02",
   "type": "ArchiveDirectory",
   "subarchives": [
     "example_broken_symlinks.tar.gz"
@@ -2547,6 +2555,7 @@ d1ee10b76e42d7e06921e41fbb9b75f7  example/subdir3/ex1.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "subarchives": [
     "example.tar.gz"
   ],
@@ -3721,6 +3730,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir2/ex3.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "CopyArchiveDirectory",
   "user": "anon",
   "creation_date": "2023-06-16 09:58:39",
@@ -3772,6 +3782,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir2/ex4.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "CopyArchiveDirectory",
   "user": "anon",
   "creation_date": "2023-06-16 09:58:39",
@@ -3823,6 +3834,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir3/ex3.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "CopyArchiveDirectory",
   "user": "anon",
   "creation_date": "2023-06-16 09:58:39",
@@ -3874,6 +3886,7 @@ afb5e9e75190eea73d05fa5b0c20bd51  subdir2/ex4.txt
                             content="""{
   "name": "example",
   "source": "/original/path/to/example",
+  "source_date": "2019-11-27 17:19:02",
   "type": "CopyArchiveDirectory",
   "user": "anon",
   "creation_date": "2023-06-16 09:58:39",


### PR DESCRIPTION
Adds a `source_date` item to the archiver metadata JSON file (`ARCHIVE_METADATA/archiver_metadata.json`) which is added to compressed and copy archive directories. This new item records the timestamp of the source directory.

(The PR also abstracts the format string into a constant in the `archive` module, to make it easier to ensure that the timestamp formats are consistent within the library.)