### PR TITLE
Add README files to compressed and copy archive directories

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -42,6 +42,8 @@ logging.basicConfig(level="INFO",format='%(levelname)s: %(message)s')
 # Module constants
 #######################################################################
 
+GITHUB_URL = "https://github.com/fls-bioinformatics-core/ngsarchiver"
+ZENODO_URL = "https://doi.org/10.5281/zenodo.14024309"
 MD5_BLOCKSIZE = 1024*1024
 
 #######################################################################
@@ -1707,9 +1709,7 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
                f"located at {d.path}")
     readme.add(f"The archive was created using the 'ngsarchiver' utility "
                f"version {get_version()} (which is hosted on Github at "
-               f"https://github.com/fls-bioinformatics-core/ngsarchiver and "
-               f"is archived on Zenodo at "
-               f"https://doi.org/10.5281/zenodo.14024309).")
+               f"{GITHUB_URL} and is archived on Zenodo at {ZENODO_URL}).")
     if not sub_dirs:
         # All files in a single archive
         if not multi_volume:
@@ -2239,9 +2239,7 @@ def make_copy(d, dest, replace_symlinks=False,
                f"located at {d.path}")
     readme.add(f"The archive was created using the 'ngsarchiver' utility "
                f"version {get_version()} (which is hosted on Github at "
-               f"https://github.com/fls-bioinformatics-core/ngsarchiver and "
-               f"is archived on Zenodo at "
-               f"https://doi.org/10.5281/zenodo.14024309).")
+               f"{GITHUB_URL} and is archived on Zenodo at {ZENODO_URL}).")
     if not (replace_symlinks or transform_broken_symlinks or follow_dirlinks):
         readme.add(f"All files and directories in the source directory "
                    "have been copied to this directory as-is (preserving "

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1440,6 +1440,7 @@ class ReadmeFile:
     """
     def __init__(self):
         self._textwrapper = textwrap.TextWrapper(break_long_words=False,
+                                                 break_on_hyphens=False,
                                                  replace_whitespace=False)
         self._contents = []
 

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1701,6 +1701,82 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     json_file = os.path.join(ngsarchiver_dir, "archiver_metadata.json")
     with open(json_file,'wt') as fp:
         json.dump(archive_metadata,fp,indent=2)
+    # Add a README
+    readme = ReadmeFile()
+    readme.add(f"This is a compressed archive of the directory originally "
+               f"located at {d.path}")
+    readme.add(f"The archive was created using the 'ngsarchiver' utility "
+               f"version {get_version()} (which is hosted on Github at "
+               f"https://github.com/fls-bioinformatics-core/ngsarchiver and "
+               f"is archived on Zenodo at "
+               f"https://doi.org/10.5281/zenodo.14024309).")
+    if not sub_dirs:
+        # All files in a single archive
+        if not multi_volume:
+            readme.add(f"All files and directories in the source directory "
+                       f"have been put into a single compressed TAR archive "
+                       f"'{d.basename}.tar.gz'.")
+        else:
+            readme.add(f"All files and directories in the source directory "
+                       f"have been put into a set of one or more compressed "
+                       f"TAR archives '{d.basename}.*.tar.gz' where the size "
+                       f"of each archive file does not exceed {volume_size} "
+                       f"where possible.")
+    else:
+        # Subdirectories in separate archives
+        if not multi_volume:
+            readme.add(f"Each of the following subdirectories have been put "
+                       f"into a separate compressed TAR archive:")
+            for subdir in sub_dirs:
+                readme.add(f"* {subdir} -> {subdir}.tar.gz", indent="  ")
+        else:
+            readme.add(f"Each of the following subdirectories have been put "
+                       f"into a separate set of one or more compressed TAR "
+                       f"archives where the size of each archive file does "
+                       f"not exceed {volume_size} where possible:")
+            for subdir in sub_dirs:
+                readme.add(f"* {subdir} -> {subdir}.*.tar.gz", indent="  ")
+        if misc_objects:
+            # Additional TAR archive
+            if not multi_volume:
+                readme.add("An additional compressed TAR archive file "
+                           "contains file and subdirectories not in the "
+                           "above archive(s):")
+                readme.add(f"* {misc_archive_name}.tar.gz", indent="  ")
+            else:
+                readme.add("An additional set of compressed TAR archive "
+                           "files contains files and subdirectories not in "
+                           "the above archive(s):")
+                readme.add(f"* {misc_archive_name}.*.tar.gz", indent="  ")
+        if extra_files:
+            # Any files not in a TAR archive
+            readme.add("The following additional files have been copied "
+                       "directly from the source into the archive directory:")
+            for f in extra_files:
+                if os.path.isabs(f):
+                    f = os.path.relpath(f,d.path)
+                readme.add(f"* {f}", indent="  ")
+    readme.add("Each .tar.gz archive has a corresponding .md5 file with "
+               "the MD5 checksums for each of the regular files in the "
+               "archive, which can be used to verify the files when they "
+               "are unpacked.")
+    readme.add("The ARCHIVE_METADATA contains files with additional metadata "
+               "about the source files and directories:")
+    readme.add("* archive_checksums.md5: MD5 checksums for each of the "
+               ".tar.gz and other files in the top-level archive directory",
+               indent="  ")
+    readme.add("* archiver_metadata.json: JSON file with information about "
+               "how the archive was created", indent="  ")
+    readme.add("* manifest: tab-delimited file listing the original owner "
+               "and group for each archived file and directory", indent="  ")
+    if symlinks:
+        readme.add("* symlinks: tab-delimited file listing the symbolic "
+                   "links from the source directory", indent="  ")
+    readme.add("The original data can be recovered and verified using the "
+               "'ngsarchiver' utility's 'unpack' command (or by using the "
+               "'tar' and 'md5sum' Linux command line utilities directly "
+               "with the .tar.gz and MD5 checksum files)")
+    readme.write(os.path.join(temp_archive_dir, "ARCHIVE_README"))
     # Move to final location and update the attributes
     shutil.move(temp_archive_dir, archive_dir)
     shutil.copystat(d.path,archive_dir)
@@ -2157,6 +2233,57 @@ def make_copy(d, dest, replace_symlinks=False,
     json_file = os.path.join(metadata_dir, "archiver_metadata.json")
     with open(json_file, 'wt') as fp:
         json.dump(archive_metadata, fp, indent=2)
+    # Add a README
+    readme = ReadmeFile()
+    readme.add(f"This is an archive copy of the directory originally "
+               f"located at {d.path}")
+    readme.add(f"The archive was created using the 'ngsarchiver' utility "
+               f"version {get_version()} (which is hosted on Github at "
+               f"https://github.com/fls-bioinformatics-core/ngsarchiver and "
+               f"is archived on Zenodo at "
+               f"https://doi.org/10.5281/zenodo.14024309).")
+    if not (replace_symlinks or transform_broken_symlinks or follow_dirlinks):
+        readme.add(f"All files and directories in the source directory "
+                   "have been copied to this directory as-is (preserving "
+                   "file types and contents).")
+    else:
+        readme.add(f"All files and directories in the source directory "
+                   f"have been copied to this directory as-is, except for "
+                   "the following modifications:")
+        if replace_symlinks:
+            readme.add("* Symbolic links to files in the source have been "
+                       "replaced in the copy with the referent files",
+                       indent="  ")
+        if follow_dirlinks:
+            readme.add("* Symbolic links to directories in the source have "
+                       "been replaced recursively in the copy with the "
+                       "referent directories and their contents", indent="  ")
+        if transform_broken_symlinks:
+            readme.add("* Broken or unresolvable symbolic links (i.e. links "
+                       "where the target doesn't exist or cannot otherwise "
+                       "be resolved) have been replaced with placeholder "
+                       "files")
+    readme.add("The ARCHIVE_METADATA contains files with additional metadata "
+               "about the source files and directories:")
+    readme.add("* archiver_metadata.json: JSON file with information about "
+               "how the archive was created", indent="  ")
+    readme.add("* checksums.md5: MD5 checksums for each of the regular "
+               "files in the archive copy"
+               "how the archive was created", indent="  ")
+    readme.add("* manifest: tab-delimited file listing the original owner "
+               "and group for each archived file and directory", indent="  ")
+    if d.has_symlinks:
+        readme.add("* symlinks: tab-delimited file listing the symbolic "
+                   "links from the source directory", indent="  ")
+    if d.has_broken_symlinks:
+        readme.add("* broken_symlinks: tab-delimited file listing the "
+                   "broken symbolic links from the source directory",
+                   indent="  ")
+    if d.has_unresolvable_symlinks:
+        readme.add("* unresolvable_symlinks: tab-delimited file listing the "
+                   "unresolvable symbolic links from the source directory",
+                   indent="  ")
+    readme.write(os.path.join(temp_copy, "ARCHIVE_README"))
     # Move to final location
     shutil.move(temp_copy, dest)
     shutil.copystat(d.path, dest)

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -27,6 +27,7 @@ import getpass
 import tempfile
 import logging
 import pathlib
+import textwrap
 from .exceptions import NgsArchiverException
 from . import get_version
 
@@ -1429,6 +1430,52 @@ class CopyArchiveDirectory(Directory):
 
     def __repr__(self):
         return self._path
+
+
+class ReadmeFile:
+    """
+    Convenience class for creating README files
+    """
+    def __init__(self):
+        self._textwrapper = textwrap.TextWrapper(break_long_words=False,
+                                                 replace_whitespace=False)
+        self._contents = []
+
+    def add(self, text, indent=None):
+        """
+        Append text to the README
+
+        Arguments:
+          text (str): block of text to add; it will be wrapped
+            into multiple lines of 70 characters
+          indent (str): if supplied then each line will be
+            indented using this string (default: no indent)
+        """
+        if indent:
+            self._textwrapper.initial_indent = indent
+            self._textwrapper.subsequent_indent = indent
+        self._contents.append("\n".join(self._textwrapper.wrap(text)))
+        if indent:
+            self._textwrapper.initial_indent = ""
+            self._textwrapper.subsequent_indent = ""
+
+    def text(self):
+        """
+        Return the README contents as a string
+        """
+        return "\n\n".join(self._contents)
+
+    def write(self, filen):
+        """
+        Write the README to file
+
+        Arguments:
+          filen (str): path to the file to write the
+            README contents to
+        """
+        with open(filen, "wt") as fp:
+            fp.write(self.text() + "\n")
+
 
 #######################################################################
 # Functions

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2261,7 +2261,7 @@ def make_copy(d, dest, replace_symlinks=False,
             readme.add("* Broken or unresolvable symbolic links (i.e. links "
                        "where the target doesn't exist or cannot otherwise "
                        "be resolved) have been replaced with placeholder "
-                       "files")
+                       "files", indent="  ")
     readme.add("The ARCHIVE_METADATA contains files with additional metadata "
                "about the source files and directories:")
     readme.add("* archiver_metadata.json: JSON file with information about "

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1707,10 +1707,12 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     # Add a README
     readme = ReadmeFile()
     readme.add(f"This is a compressed archive of the directory originally "
-               f"located at {d.path}")
+               f"located at:")
+    readme.add(f"{d.path}")
     readme.add(f"The archive was created using the 'ngsarchiver' utility "
-               f"version {get_version()} (which is hosted on Github at "
-               f"{GITHUB_URL} and is archived on Zenodo at {ZENODO_URL}).")
+               f"(version {get_version()}), which is hosted on Github at "
+               f"{GITHUB_URL} and is also archived on Zenodo at "
+               f"{ZENODO_URL}.")
     if not sub_dirs:
         # All files in a single archive
         if not multi_volume:
@@ -1720,21 +1722,22 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
         else:
             readme.add(f"All files and directories in the source directory "
                        f"have been put into a set of one or more compressed "
-                       f"TAR archives '{d.basename}.*.tar.gz' where the size "
+                       f"TAR archives '{d.basename}.*.tar.gz' (where the size "
                        f"of each archive file does not exceed {volume_size} "
-                       f"where possible.")
+                       f"where possible).")
     else:
         # Subdirectories in separate archives
         if not multi_volume:
-            readme.add(f"Each of the following subdirectories have been put "
-                       f"into a separate compressed TAR archive:")
+            readme.add(f"Each of the following subdirectories from the source "
+                       f"have been put into a separate compressed TAR archive:")
             for subdir in sub_dirs:
                 readme.add(f"* {subdir} -> {subdir}.tar.gz", indent="  ")
         else:
-            readme.add(f"Each of the following subdirectories have been put "
-                       f"into a separate set of one or more compressed TAR "
-                       f"archives where the size of each archive file does "
-                       f"not exceed {volume_size} where possible:")
+            readme.add(f"Each of the following subdirectories from the source "
+                       f"have been put into a separate set of one or more "
+                       f"compressed TAR archives (where the size of each "
+                       f"archive file does not exceed {volume_size} where "
+                       f"possible):")
             for subdir in sub_dirs:
                 readme.add(f"* {subdir} -> {subdir}.*.tar.gz", indent="  ")
         if misc_objects:
@@ -1761,11 +1764,16 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
                "the MD5 checksums for each of the regular files in the "
                "archive, which can be used to verify the files when they "
                "are unpacked.")
-    readme.add("The ARCHIVE_METADATA contains files with additional metadata "
-               "about the source files and directories:")
+    readme.add("The original data can be recovered and verified using the "
+               "'ngsarchiver' utility's 'unpack' command (or by using the "
+               "'tar' and 'md5sum' Linux command line utilities directly "
+               "with the .tar.gz and MD5 checksum files).")
+    readme.add("The ARCHIVE_METADATA subdirectory contains files with "
+               "additional metadata about the source files and directories:")
     readme.add("* archive_checksums.md5: MD5 checksums for each of the "
-               ".tar.gz and other files in the top-level archive directory",
-               indent="  ")
+               ".tar.gz and other files in the top-level archive directory, "
+               "which can be used to verify the integrity of the archive "
+               "if copied or moved", indent="  ")
     readme.add("* archiver_metadata.json: JSON file with information about "
                "how the archive was created", indent="  ")
     readme.add("* manifest: tab-delimited file listing the original owner "
@@ -1773,10 +1781,6 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     if symlinks:
         readme.add("* symlinks: tab-delimited file listing the symbolic "
                    "links from the source directory", indent="  ")
-    readme.add("The original data can be recovered and verified using the "
-               "'ngsarchiver' utility's 'unpack' command (or by using the "
-               "'tar' and 'md5sum' Linux command line utilities directly "
-               "with the .tar.gz and MD5 checksum files)")
     readme.write(os.path.join(temp_archive_dir, "ARCHIVE_README"))
     # Move to final location and update the attributes
     shutil.move(temp_archive_dir, archive_dir)
@@ -2237,10 +2241,12 @@ def make_copy(d, dest, replace_symlinks=False,
     # Add a README
     readme = ReadmeFile()
     readme.add(f"This is an archive copy of the directory originally "
-               f"located at {d.path}")
+               f"located at:")
+    readme.add(f"{d.path}")
     readme.add(f"The archive was created using the 'ngsarchiver' utility "
-               f"version {get_version()} (which is hosted on Github at "
-               f"{GITHUB_URL} and is archived on Zenodo at {ZENODO_URL}).")
+               f"(version {get_version()}), which is hosted on Github at "
+               f"{GITHUB_URL} and is also archived on Zenodo at "
+               f"{ZENODO_URL}.")
     if not (replace_symlinks or transform_broken_symlinks or follow_dirlinks):
         readme.add(f"All files and directories in the source directory "
                    "have been copied to this directory as-is (preserving "
@@ -2262,13 +2268,12 @@ def make_copy(d, dest, replace_symlinks=False,
                        "where the target doesn't exist or cannot otherwise "
                        "be resolved) have been replaced with placeholder "
                        "files", indent="  ")
-    readme.add("The ARCHIVE_METADATA contains files with additional metadata "
-               "about the source files and directories:")
+    readme.add("The ARCHIVE_METADATA subdirectory contains files with "
+               "additional metadata about the source files and directories:")
     readme.add("* archiver_metadata.json: JSON file with information about "
                "how the archive was created", indent="  ")
     readme.add("* checksums.md5: MD5 checksums for each of the regular "
-               "files in the archive copy"
-               "how the archive was created", indent="  ")
+               "files in the archive copy", indent="  ")
     readme.add("* manifest: tab-delimited file listing the original owner "
                "and group for each archived file and directory", indent="  ")
     if d.has_symlinks:

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -20,6 +20,7 @@ from ngsarchiver.archive import MultiProjectRun
 from ngsarchiver.archive import ArchiveDirectory
 from ngsarchiver.archive import ArchiveDirMember
 from ngsarchiver.archive import CopyArchiveDirectory
+from ngsarchiver.archive import ReadmeFile
 from ngsarchiver.archive import get_rundir_instance
 from ngsarchiver.archive import md5sum
 from ngsarchiver.archive import verify_checksums
@@ -3892,6 +3893,61 @@ afb5e9e75190eea73d05fa5b0c20bd51  subdir2/ex4.txt
         self.assertTrue(c.verify_archive())
         # Check against source directory
         self.assertTrue(c.verify_copy(example_src.path))
+
+
+class TestReadmeFile(unittest.TestCase):
+
+    def setUp(self):
+        self.wd = tempfile.mkdtemp(suffix='TestReadmeFile')
+
+    def tearDown(self):
+        if REMOVE_TEST_OUTPUTS:
+            shutil.rmtree(self.wd)
+
+    def test_readmefile(self):
+        """
+        ReadmeFile: test creating a README file
+        """
+        readme = ReadmeFile()
+        self.assertEqual(readme.text(), "")
+        readme.add("Some content")
+        self.assertEqual(readme.text(), "Some content")
+        readme.add("More content")
+        self.assertEqual(readme.text(), "Some content\n\nMore content")
+        readme_file = os.path.join(self.wd, "README")
+        readme.write(readme_file)
+        self.assertTrue(os.path.exists(readme_file))
+        with open(readme_file, "rt") as fp:
+            contents = fp.read()
+            self.assertEqual(contents, "Some content\n\nMore content\n")
+
+    def test_readmefile_wrap_lines(self):
+        """
+        ReadmeFile: test wrapping long lines
+        """
+        readme = ReadmeFile()
+        self.assertEqual(readme.text(), "")
+        readme.add("Some content which exceeds the 70 character width "
+                   "limit and so must be wrapped onto multiple lines")
+        self.assertEqual(readme.text(),
+                         "Some content which exceeds the 70 character "
+                         "width limit and so must be\nwrapped onto "
+                         "multiple lines")
+
+    def test_readmefile_indent_lines(self):
+        """
+        ReadmeFile: test indenting lines
+        """
+        readme = ReadmeFile()
+        self.assertEqual(readme.text(), "")
+        readme.add("Some content which exceeds the 70 character width "
+                   "limit and so must be wrapped onto multiple lines",
+                   indent="   ")
+        self.assertEqual(readme.text(),
+                         "   Some content which exceeds the 70 character "
+                         "width limit and so must\n   be wrapped onto "
+                         "multiple lines")
+
 
 class TestGetRundirInstance(unittest.TestCase):
 

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -1391,6 +1391,7 @@ d1ee10b76e42d7e06921e41fbb9b75f7  example/subdir3/ex1.txt
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1514,6 +1515,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1645,6 +1647,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1783,6 +1786,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1943,6 +1947,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -2130,6 +2135,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 }
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -2252,6 +2258,7 @@ a03dcb0295d903ee194ccb117b41f870  example_external_symlinks/subdir3/ex2.txt
                             content="""example_external_symlinks/subdir2/external_symlink1.txt	example_external_symlinks.tar.gz
 example_external_symlinks/subdir1/symlink1.txt	example_external_symlinks.tar.gz
 """)
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Add an external file
@@ -2407,6 +2414,7 @@ a03dcb0295d903ee194ccb117b41f870  example_broken_symlinks/subdir3/ex2.txt
                             content="""example_broken_symlinks/subdir2/broken_symlink1.txt	example_broken_symlinks.tar.gz
 example_broken_symlinks/subdir1/symlink1.txt	example_broken_symlinks.tar.gz
 """)
+        example_archive.add("ARCHIVE_README",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -4042,6 +4050,36 @@ class TestGetRundirInstance(unittest.TestCase):
 }
 """)
         example_dir.add("ARCHIVE_METADATA/manifest.txt",type="file")
+        example_dir.add("ARCHIVE_README",type="file")
+        example_dir.add("Project1.tar.gz",type="file")
+        example_dir.add("Project2.tar.gz",type="file")
+        example_dir.add("undetermined.tar.gz",type="file")
+        example_dir.add("processing.tar.gz",type="file")
+        example_dir.add("Project1.md5",type="file")
+        example_dir.add("Project2.md5",type="file")
+        example_dir.add("undetermined.md5",type="file")
+        example_dir.add("processing.md5",type="file")
+        example_dir.create()
+        p = example_dir.path
+        p = example_dir.path
+        # Check correct class is returned
+        d = get_rundir_instance(p)
+        self.assertTrue(isinstance(d,ArchiveDirectory))
+
+    def test_get_rundir_instance_archive_directory_no_readme(self):
+        """
+        get_rundir_instance: returns 'ArchiveDirectory' instance (no README)
+        """
+        # Build example dir
+        example_dir = UnittestDir(os.path.join(self.wd,"example.archive"))
+        example_dir.add("ARCHIVE_METADATA/archive_checksums.md5",type="file")
+        example_dir.add("ARCHIVE_METADATA/archiver_metadata.json",type="file",
+                        content="""{
+  "name": "example",
+  "compression_level": 6
+}
+""")
+        example_dir.add("ARCHIVE_METADATA/manifest.txt",type="file")
         example_dir.add("Project1.tar.gz",type="file")
         example_dir.add("Project2.tar.gz",type="file")
         example_dir.add("undetermined.tar.gz",type="file")
@@ -4263,6 +4301,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "example.01.tar.gz",
                     "example.00.md5",
                     "example.01.md5",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4309,6 +4348,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "subdir1.01.md5",
                     "subdir2.00.md5",
                     "subdir2.01.md5",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4365,6 +4405,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "miscellaneous.01.tar.gz",
                     "miscellaneous.00.md5",
                     "miscellaneous.01.md5",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4426,6 +4467,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "miscellaneous.01.md5",
                     "ex5.txt",
                     "ex6.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4461,6 +4503,7 @@ class TestMakeArchiveDir(unittest.TestCase):
         self.assertTrue(os.path.exists(archive_dir))
         expected = ("example.tar.gz",
                     "example.md5",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -5158,6 +5201,7 @@ class TestMakeCopy(unittest.TestCase):
         expected = ("ex1.txt",
                     "subdir",
                     "subdir/ex2.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/checksums.md5",
@@ -5166,7 +5210,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -5212,6 +5257,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/.ex3.txt",
                     ".subdir",
                     ".subdir/ex4.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/checksums.md5",
@@ -5220,7 +5266,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -5265,6 +5312,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/symlink1.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5274,7 +5322,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -5332,6 +5381,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/rel_ext_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5342,6 +5392,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5398,6 +5449,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/broken_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5409,6 +5461,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5475,6 +5528,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/link1.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/checksums.md5",
@@ -5483,7 +5537,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -5532,6 +5587,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/ex3.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5541,7 +5597,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -5603,6 +5660,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/rel_ext_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5613,6 +5671,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5677,6 +5736,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/symlink_to_self",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5688,6 +5748,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                not os.path.basename(item) == "symlink_to_self":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5781,6 +5842,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir",
                     "subdir/ex2.txt",
                     "subdir/broken_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5792,6 +5854,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5865,6 +5928,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/ex2.txt",
                     "subdir/rel_ext_symlink.txt",
                     "subdir/broken_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5876,6 +5940,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -5921,6 +5986,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/ex2.txt",
                     "subdir/rel_ext_symlink.txt",
                     "subdir/broken_symlink.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -5932,6 +5998,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.lexists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                "symlink" not in item:
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
@@ -6008,6 +6075,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/ex2.txt",
                     "subdir/broken_link",
                     "subdir/symlink_to_broken",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -6019,6 +6087,7 @@ class TestMakeCopy(unittest.TestCase):
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
             if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README" and \
                os.path.basename(item) not in ("broken_link",
                                               "symlink_to_broken"):
                 self.assertEqual(
@@ -6098,6 +6167,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/external_dir/ex5.txt",
                     "subdir/external_dir/subdir2/",
                     "subdir/external_dir/subdir2/ex6.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA/",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -6107,7 +6177,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -6134,7 +6205,8 @@ class TestMakeCopy(unittest.TestCase):
             for line in fp:
                 manifest_file_list.append(line.rstrip().split("\t")[-1])
             for item in [x for x in expected
-                         if not x.startswith("ARCHIVE_METADATA")]:
+                         if not x.startswith("ARCHIVE_METADATA") and
+                         x != "ARCHIVE_README"]:
                 self.assertTrue(item in manifest_file_list,
                                 f"{item}: not in manifest")
         # Check that checksum file contains all the (non-symlink) files
@@ -6145,6 +6217,7 @@ class TestMakeCopy(unittest.TestCase):
                 checksum_file_list.append(line.rstrip().split("  ")[-1])
             for item in [x for x in expected
                          if not x.startswith("ARCHIVE_METADATA/") and
+                         x != "ARCHIVE_README" and
                          os.path.basename(x) not in ("ex3.txt", "ex5.txt")]:
                 if os.path.isfile(os.path.join(dest_dir, item)):
                     self.assertTrue(item in checksum_file_list,
@@ -6199,6 +6272,7 @@ class TestMakeCopy(unittest.TestCase):
                     "subdir/external_dir/ex5.txt",
                     "subdir/external_dir/subdir2/",
                     "subdir/external_dir/subdir2/ex6.txt",
+                    "ARCHIVE_README",
                     "ARCHIVE_METADATA/",
                     "ARCHIVE_METADATA/manifest",
                     "ARCHIVE_METADATA/symlinks",
@@ -6208,7 +6282,8 @@ class TestMakeCopy(unittest.TestCase):
             self.assertTrue(
                 os.path.exists(os.path.join(dest_dir, item)),
                 "missing '%s'" % item)
-            if not item.startswith("ARCHIVE_METADATA"):
+            if not item.startswith("ARCHIVE_METADATA") and \
+               item != "ARCHIVE_README":
                 self.assertEqual(
                     os.path.getmtime(os.path.join(p, item)),
                     os.path.getmtime(os.path.join(dest_dir, item)),
@@ -6235,7 +6310,8 @@ class TestMakeCopy(unittest.TestCase):
             for line in fp:
                 manifest_file_list.append(line.rstrip().split("\t")[-1])
             for item in [x for x in expected
-                         if not x.startswith("ARCHIVE_METADATA/")]:
+                         if not x.startswith("ARCHIVE_METADATA/") and
+                         x != "ARCHIVE_README"]:
                 self.assertTrue(item in manifest_file_list,
                                 f"{item}: not in manifest")
         # Check that checksum file contains all the files
@@ -6245,7 +6321,8 @@ class TestMakeCopy(unittest.TestCase):
             for line in fp:
                 checksum_file_list.append(line.rstrip().split("  ")[-1])
             for item in [x for x in expected
-                         if not x.startswith("ARCHIVE_METADATA/")]:
+                         if not x.startswith("ARCHIVE_METADATA/") and
+                         x != "ARCHIVE_README"]:
                 if os.path.isfile(os.path.join(dest_dir, item)):
                     self.assertTrue(item in checksum_file_list,
                                     f"{item}: not in checksum file")


### PR DESCRIPTION
Updates the `make_archive_dir` and `make_copy` functions to include a "README" file (called `ARCHIVE_README`) in the resulting compressed and copy archive directories.

Each file is intended to give a description of the archive contents and metadata (for example, for a compressed archive it describes what the `.tar.gz` and `.md5` files refer too).

The PR implements a new utility class `ReadmeFile` which is used to populate and write these files.