### PR TITLE
Update the command help and ordering in the CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,9 +221,9 @@ basic information in a single tab-delimited line
 for each directory. (Note that this option is not
 compatible with the ``--list`` option).
 
-------------------------------
-``archive``: create an archive
-------------------------------
+----------------------------------------
+``archive``: create a compressed archive
+----------------------------------------
 
 Makes a compressed archive directory from the specified
 directory, for example in its simplest form:
@@ -275,135 +275,14 @@ compression level to be explicitly set on the
 command line if a higher or lower level of
 compression is required.
 
----------------------------------------
-``verify``: verifying archive integrity
----------------------------------------
+-----------------------------------------
+``copy``: create a copy archive directory
+-----------------------------------------
 
-Checks the integrity of an archive directory created
-by the ``archive`` command, for example:
-
-::
-
-   archiver verify /PATH/TO/ARCHIVE_DIR
-
---------------------------------
-``unpack``: unpacking an archive
---------------------------------
-
-Restores a complete copy of the original directory
-from an archive directory, for example in its
-simplest form:
-
-::
-
-   archiver unpack /PATH/TO/ARCHIVE_DIR
-
-By default the restored copy will be created in the
-current working directory. Note that an existing
-directory with the same name will not be overwritten.
-
-The restored archive contents are also verified using
-their original checksums as part of the unpacking.
-
-The timestamps and permissions of the contents are
-also restored (with the caveat that all restored
-content will have read-write permission added for the
-user unpacking the archive, regardless of the
-permissions of the original files).
-
-Ownership information is not restored (unless the
-archiving and unpacking operations are both performed
-by superuser).
-
-If only a subset of files need to be restored from
-the archive then the ``extract`` command is recommended
-instead of the full ``unpack``.
-
------------------------------------------------------
-``compare``: verify unpacked archive against original
------------------------------------------------------
-
-Compares the contents of two directories against
-each other, and is provided to enable a restored
-archive to be checked against the original directory
-(for example before it is removed from the system):
-
-::
-
-   archiver compare /PATH/TO/DIR1 /PATH/TO/DIR2
-
-The comparison checks for missing and extra files, and
-that files have the same checksums.
-
-(Note however that it doesn't check timestamps,
-permissions or ownership.)
-
--------------------------------------
-``search``: searching within archives
--------------------------------------
-
-Locates files within one or more achive directories
-using shell-style pattern matching based loosely on
-that available in the Linux ``find`` command.
-
-For example to search for all gzipped Fastq files:
-
-::
-
-   archiver search -name "*.fastq.gz" /PATH/TO/ARCHIVE_DIR
-
-Using ``-name`` only considers the filename part of
-the archived files; alternatively ``-path`` can be
-used to include whole paths, for example:
-
-::
-
-   archiver search -path "*/*.fastq.gz" /PATH/TO/ARCHIVE_DIR
-
-Multiple archive directories can also be specified in
-a single ``search`` command invocation, in which case
-the search will be performed across all the specified
-archives.
-
-------------------------------------------------------
-``extract``: extracting specific files and directories
-------------------------------------------------------
-
-Restores a subset of files from an archive directory
-using shell-style pattern matching.
-
-For example to extract all gzipped Fastq files:
-
-::
-
-   archiver extract -name "*.fastq.gz" /PATH/TO/ARCHIVE_DIR
-
-By default the matching files will be extracted to
-the current working directory with their leading
-paths removed; to keep the full paths for the
-extracted files use the ``-k`` option.
-
-Note that existing files with the same name will not
-be overwritten.
-
-Note also that the ``-name`` option operates slightly
-differently to the ``search`` command, as in this
-case it will match both filenames and paths.
-
-Extracted files will have the same timestamps and
-permissions as the originals (with the caveat that all
-restored content will have read-write permission added
-for the user extracting the files, regardless of the
-permissions of the originals).
-
--------------------------------------------------
-``copy``: copy a directory to an archive location
--------------------------------------------------
-
-Copies any directory and its contents to another
-location for archiving purposes, but without
-performing compression (a "copy archive
-directory").
+Makes a copy archive directory from the specified
+directory, essentially copying the directory and
+its contents to another location without performing
+compression.
 
 At its most basic this is a straight copy of the
 source directory, with some metadata files added.
@@ -502,6 +381,131 @@ Note that if using ``--follow-dirlinks``, that the
 copied directories are not checked before starting the
 copy operation, and so may contain "problem" entities
 which can cause the operation to fail.
+
+---------------------------------------
+``verify``: verifying archive integrity
+---------------------------------------
+
+Checks the integrity of an archive directory created
+by the ``archive`` command, for example:
+
+::
+
+   archiver verify /PATH/TO/ARCHIVE_DIR
+
+------------------------------------------
+``unpack``: unpacking a compressed archive
+------------------------------------------
+
+Restores a complete copy of the original directory
+from an archive directory, for example in its
+simplest form:
+
+::
+
+   archiver unpack /PATH/TO/ARCHIVE_DIR
+
+By default the restored copy will be created in the
+current working directory. Note that an existing
+directory with the same name will not be overwritten.
+
+The restored archive contents are also verified using
+their original checksums as part of the unpacking.
+
+The timestamps and permissions of the contents are
+also restored (with the caveat that all restored
+content will have read-write permission added for the
+user unpacking the archive, regardless of the
+permissions of the original files).
+
+Ownership information is not restored (unless the
+archiving and unpacking operations are both performed
+by superuser).
+
+If only a subset of files need to be restored from
+the archive then the ``extract`` command is recommended
+instead of the full ``unpack``.
+
+------------------------------------------------
+``search``: searching within compressed archives
+------------------------------------------------
+
+Locates files within one or more compressed achive
+directories using shell-style pattern matching based
+loosely on that available in the Linux ``find``
+command.
+
+For example to search for all gzipped Fastq files:
+
+::
+
+   archiver search -name "*.fastq.gz" /PATH/TO/ARCHIVE_DIR
+
+Using ``-name`` only considers the filename part of
+the archived files; alternatively ``-path`` can be
+used to include whole paths, for example:
+
+::
+
+   archiver search -path "*/*.fastq.gz" /PATH/TO/ARCHIVE_DIR
+
+Multiple archive directories can also be specified in
+a single ``search`` command invocation, in which case
+the search will be performed across all the specified
+archives.
+
+------------------------------------------------------
+``extract``: extracting specific files and directories
+------------------------------------------------------
+
+Restores a subset of files from a compressed archive
+directory using shell-style pattern matching.
+
+For example to extract all gzipped Fastq files:
+
+::
+
+   archiver extract -name "*.fastq.gz" /PATH/TO/ARCHIVE_DIR
+
+By default the matching files will be extracted to
+the current working directory with their leading
+paths removed; to keep the full paths for the
+extracted files use the ``-k`` option.
+
+Note that existing files with the same name will not
+be overwritten.
+
+Note also that the ``-name`` option operates slightly
+differently to the ``search`` command, as in this
+case it will match both filenames and paths.
+
+Extracted files will have the same timestamps and
+permissions as the originals (with the caveat that all
+restored content will have read-write permission added
+for the user extracting the files, regardless of the
+permissions of the originals).
+
+--------------------------------------------------
+``compare``: check if two directories are the same
+--------------------------------------------------
+
+Compares the contents of two directories against
+each other, and raises an error if the contents
+differ.
+
+``compare`` is provided primarily to enable a restored
+archive to be checked against the original directory
+(for example before it is removed from the system):
+
+::
+
+   archiver compare /PATH/TO/DIR1 /PATH/TO/DIR2
+
+The comparison checks for missing and extra files, and
+that files have the same checksums.
+
+(Note however that it doesn't check timestamps,
+permissions or ownership.)
 
 -----------------------------------
 Compressed archive directory format

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -112,6 +112,38 @@ def main(argv=None):
                                 "archiving anyway (may result in "
                                 "incomplete or problematic archive)")
 
+    # 'copy' command
+    parser_copy = s.add_parser('copy',
+                               help="make copy archive of a directory")
+    parser_copy.add_argument('dir',
+                             help="path to directory")
+    parser_copy.add_argument('dest_dir', nargs="?",
+                             help="create copy under 'dest_dir' "
+                             "(default: current directory)")
+    parser_copy.add_argument('-c','--check',action='store_true',
+                             help="check for and warn about potential "
+                             "issues; don't perform copying")
+    parser_copy.add_argument('-r','--replace-symlinks',action='store_true',
+                             help="replace symbolic links with their "
+                             "target (default is to copy links as-is; will "
+                             "fail for broken links unless '-t' option "
+                             "is also specified; will fail for dirlinks "
+                             "unless '-f' option is also specified)")
+    parser_copy.add_argument('-f','--follow-dirlinks',action='store_true',
+                             help="replace dirlinks (symbolic links to "
+                             "directories) with actual directories, and "
+                             "recursively copy the contents of those "
+                             "directories")
+    parser_copy.add_argument('-t','--transform-broken-symlinks',
+                             action='store_true',
+                             help="replace broken and unresolvable symbolic "
+                             "links with placeholder files (default is to "
+                             "copy broken and unresolvable links as-is)")
+    parser_copy.add_argument('--force',action='store_true',
+                             help="ignore issues and perform "
+                             "copy anyway (may result in incomplete "
+                             "or problematic copy)")
+
     # 'verify' command
     parser_verify = s.add_parser('verify',
                                   help="verify integrity of an archive "
@@ -130,15 +162,6 @@ def main(argv=None):
                                action='store',dest='out_dir',
                                help="unpack archive under OUT_DIR "
                                "(default: current directory)")
-
-    # 'compare' command
-    parser_compare = s.add_parser('compare',
-                                  help="check one directory against "
-                                  "another")
-    parser_compare.add_argument('dir1',
-                                help="path to first directory")
-    parser_compare.add_argument('dir2',
-                                help="path to second directory")
 
     # 'search' command
     parser_search = s.add_parser('search',
@@ -174,37 +197,14 @@ def main(argv=None):
                                 "paths when extracting files (default "
                                 "is to drop leading paths)")
 
-    # 'copy' command
-    parser_copy = s.add_parser('copy',
-                               help="make direct copy of a directory")
-    parser_copy.add_argument('dir',
-                             help="path to directory")
-    parser_copy.add_argument('dest_dir', nargs="?",
-                             help="create copy under 'dest_dir' "
-                             "(default: current directory)")
-    parser_copy.add_argument('-c','--check',action='store_true',
-                             help="check for and warn about potential "
-                             "issues; don't perform copying")
-    parser_copy.add_argument('-r','--replace-symlinks',action='store_true',
-                             help="replace symbolic links with their "
-                             "target (default is to copy links as-is; will "
-                             "fail for broken links unless '-t' option "
-                             "is also specified; will fail for dirlinks "
-                             "unless '-f' option is also specified)")
-    parser_copy.add_argument('-f','--follow-dirlinks',action='store_true',
-                             help="replace dirlinks (symbolic links to "
-                             "directories) with actual directories, and "
-                             "recursively copy the contents of those "
-                             "directories")
-    parser_copy.add_argument('-t','--transform-broken-symlinks',
-                             action='store_true',
-                             help="replace broken and unresolvable symbolic "
-                             "links with placeholder files (default is to "
-                             "copy broken and unresolvable links as-is)")
-    parser_copy.add_argument('--force',action='store_true',
-                             help="ignore issues and perform "
-                             "copy anyway (may result in incomplete "
-                             "or problematic copy)")
+    # 'compare' command
+    parser_compare = s.add_parser('compare',
+                                  help="check if two directories have the "
+                                  "same contents")
+    parser_compare.add_argument('dir1',
+                                help="path to first directory")
+    parser_compare.add_argument('dir2',
+                                help="path to second directory")
 
     # Parse the arguments
     args = p.parse_args(argv)

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -81,7 +81,8 @@ def main(argv=None):
 
     # 'archive' command
     parser_archive = s.add_parser('archive',
-                                  help="make archive copy of a directory")
+                                  help="make compressed archive of a "
+                                  "directory")
     parser_archive.add_argument('dir',
                                 help="path to directory")
     parser_archive.add_argument('-o','--out-dir',metavar='OUT_DIR',
@@ -116,14 +117,15 @@ def main(argv=None):
                                   help="verify integrity of an archive "
                                  "directory")
     parser_verify.add_argument('archive',
-                               help="path to archive directory")
+                               help="path to compressed or copy archive "
+                               "directory")
 
     # 'unpack' command
     parser_unpack = s.add_parser('unpack',
-                                  help="unpack (extract) all files from an "
-                                 "archive")
+                                  help="extract all files from a "
+                                 "compressed archive")
     parser_unpack.add_argument('archive',
-                               help="path to archive directory")
+                               help="path to compressed archive directory")
     parser_unpack.add_argument('-o','--out-dir',metavar='OUT_DIR',
                                action='store',dest='out_dir',
                                help="unpack archive under OUT_DIR "
@@ -140,7 +142,7 @@ def main(argv=None):
 
     # 'search' command
     parser_search = s.add_parser('search',
-                                 help="search within one or more archives")
+                                 help="search within compressed archives")
     parser_search.add_argument('archives',
                                nargs="+",metavar="archive",
                                help="path to archive directory")
@@ -155,10 +157,10 @@ def main(argv=None):
 
     # 'extract' command
     parser_extract = s.add_parser('extract',
-                                  help="extract specific files from an "
-                                  "archive")
+                                  help="extract specific files from "
+                                  "compressed archive")
     parser_extract.add_argument('archive',
-                                help="path to archive directory")
+                                help="path to compressed archive directory")
     parser_extract.add_argument('-name',action='store',
                                 help="name or pattern to match base "
                                 "of file names to be extracted")


### PR DESCRIPTION
Updates the help text for various commands in the CLI which only work for compressed archives (to clarify this fact), and to clarify that the `copy` command also creates an archive. Also reorders the commands in the CLI and updates the `README` document to clarify the function of some of the commands.