### PR TITLE
Add unpacking instructions to compressed archive README files

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1778,7 +1778,7 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
             # Additional TAR archive
             if not multi_volume:
                 readme.add("An additional compressed TAR archive file "
-                           "contains file and subdirectories not in the "
+                           "contains files and subdirectories not in the "
                            "above archive(s):")
                 readme.add(f"* {misc_archive_name}.tar.gz", indent="  ")
             else:

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1439,9 +1439,15 @@ class CopyArchiveDirectory(Directory):
 class ReadmeFile:
     """
     Convenience class for creating README files
+
+    Arguments:
+      width (int): if supplied then sets the maximum length
+        before wrapping long lines (default: 70)
     """
-    def __init__(self):
-        self._width = 70
+    def __init__(self, width=None):
+        if width is None:
+            width = 70
+        self._width = int(width)
         self._textwrapper = textwrap.TextWrapper(width=self._width,
                                                  break_long_words=False,
                                                  break_on_hyphens=False,

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1441,12 +1441,14 @@ class ReadmeFile:
     Convenience class for creating README files
     """
     def __init__(self):
-        self._textwrapper = textwrap.TextWrapper(break_long_words=False,
+        self._width = 70
+        self._textwrapper = textwrap.TextWrapper(width=self._width,
+                                                 break_long_words=False,
                                                  break_on_hyphens=False,
-                                                 replace_whitespace=False)
+                                                 replace_whitespace=True)
         self._contents = []
 
-    def add(self, text, indent=None):
+    def add(self, text, indent=None, wrap=True, keep_newlines=False):
         """
         Append text to the README
 
@@ -1455,14 +1457,32 @@ class ReadmeFile:
             into multiple lines of 70 characters
           indent (str): if supplied then each line will be
             indented using this string (default: no indent)
+          wrap (bool): if True (the default) then wrap the text
+            to the default width; otherwise don't wrap
+          keep_newlines (bool): if False (the default) then
+            newlines in the text are removed; if True then
+            they are kept
         """
         if indent:
             self._textwrapper.initial_indent = indent
             self._textwrapper.subsequent_indent = indent
-        self._contents.append("\n".join(self._textwrapper.wrap(text)))
-        if indent:
+        else:
             self._textwrapper.initial_indent = ""
             self._textwrapper.subsequent_indent = ""
+        if wrap:
+            self._textwrapper.width = self._width
+        else:
+            if indent:
+                self._textwrapper.width = len(text) + len(indent) + 1
+            else:
+                self._textwrapper.width = len(text) + 1
+        if keep_newlines:
+            new_text = []
+            for line in text.split("\n"):
+                new_text.append("\n".join(self._textwrapper.wrap(line)))
+            self._contents.append("\n".join(new_text))
+        else:
+            self._contents.append("\n".join(self._textwrapper.wrap(text)))
 
     def text(self):
         """

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1799,9 +1799,39 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
                "archive, which can be used to verify the files when they "
                "are unpacked.")
     readme.add("The original data can be recovered and verified using the "
-               "'ngsarchiver' utility's 'unpack' command (or by using the "
-               "'tar' and 'md5sum' Linux command line utilities directly "
-               "with the .tar.gz and MD5 checksum files).")
+               "'ngsarchiver' utility's 'unpack' command, for example:")
+    readme.add(f"$ archiver unpack {d.basename}.archive",
+               indent="    ", wrap=False, keep_newlines=True)
+    readme.add("It is also possible to restore the original data using the "
+               "Linux 'tar' and 'md5sum' command line utilities directly "
+               "with the .tar.gz and MD5 checksum files. For example, to "
+               "recover the original directory and its contents into the "
+               "current working directory:")
+    if not sub_dirs:
+        if not multi_volume:
+            readme.add(
+                f"$ tar zxvf {d.basename}.archive/{d.basename}.tar.gz\n"
+                f"$ md5sum -c {d.basename}.archive/{d.basename}.md5",
+                indent="    ", wrap=False, keep_newlines=True)
+        else:
+            readme.add(
+                f"$ cat {d.basename}.archive/{d.basename}.*.tar.gz | "
+                f"tar zxvf - -i\n"
+                f"$ md5sum -c {d.basename}.archive/*.md5",
+                indent="    ", wrap=False, keep_newlines=True)
+    else:
+        if extra_files:
+            readme.add(
+                f"$ mkdir {d.basename}\n"
+                f"$ cp -a {d.basename}.archive/projects.info {d.basename}\n"
+                f"$ cat {d.basename}.archive/*.tar.gz | tar zxvf - -i\n"
+                f"$ md5sum -c {d.basename}.archive/*.md5",
+                indent="    ", wrap=False, keep_newlines=True)
+        else:
+            readme.add(
+                f"$ cat {d.basename}.archive/*.tar.gz | tar zxvf - -i\n"
+                f"$ md5sum -c {d.basename}.archive/*.md5",
+                indent="    ", wrap=False, keep_newlines=True)
     readme.add("The ARCHIVE_METADATA subdirectory contains files with "
                "additional metadata about the source files and directories:")
     readme.add("* archive_checksums.md5: MD5 checksums for each of the "

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -47,6 +47,7 @@ GITHUB_URL = "https://github.com/fls-bioinformatics-core/ngsarchiver"
 ZENODO_URL = "https://doi.org/10.5281/zenodo.14024309"
 MD5_BLOCKSIZE = 1024*1024
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+README_LINE_WIDTH = 75
 
 #######################################################################
 # Classes
@@ -1738,7 +1739,7 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     with open(json_file,'wt') as fp:
         json.dump(archive_metadata,fp,indent=2)
     # Add a README
-    readme = ReadmeFile()
+    readme = ReadmeFile(width=README_LINE_WIDTH)
     readme.add(f"This is a compressed archive of the directory originally "
                f"located at:")
     readme.add(f"{d.path}")
@@ -2275,7 +2276,7 @@ def make_copy(d, dest, replace_symlinks=False,
     with open(json_file, 'wt') as fp:
         json.dump(archive_metadata, fp, indent=2)
     # Add a README
-    readme = ReadmeFile()
+    readme = ReadmeFile(width=README_LINE_WIDTH)
     readme.add(f"This is an archive copy of the directory originally "
                f"located at:")
     readme.add(f"{d.path}")

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -3955,6 +3955,19 @@ class TestReadmeFile(unittest.TestCase):
                          "width limit and so must be\nwrapped onto "
                          "multiple lines")
 
+    def test_readmefile_wrap_lines_custom_width(self):
+        """
+        ReadmeFile: test wrapping long lines with custom width
+        """
+        readme = ReadmeFile(width=50)
+        self.assertEqual(readme.text(), "")
+        readme.add("Some content which exceeds the 50 character width "
+                   "limit and so must be wrapped onto multiple lines")
+        self.assertEqual(readme.text(),
+                         "Some content which exceeds the 50 character "
+                         "width\nlimit and so must be wrapped onto "
+                         "multiple lines")
+
     def test_readmefile_indent_lines(self):
         """
         ReadmeFile: test indenting lines

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -3969,6 +3969,39 @@ class TestReadmeFile(unittest.TestCase):
                          "width limit and so must\n   be wrapped onto "
                          "multiple lines")
 
+    def test_readmefile_no_wrapping(self):
+        """
+        ReadmeFile: test disabling wrapping long lines
+        """
+        readme = ReadmeFile()
+        self.assertEqual(readme.text(), "")
+        readme.add("Some content which exceeds the 70 character width "
+                   "limit and will be wrapped")
+        readme.add("More content also exceeding 70 characters but will not "
+                   "be wrapped", wrap=False)
+        readme.add("Additional long content which will again be wrapped "
+                   "over multiple lines")
+        self.assertEqual(readme.text(),
+                         "Some content which exceeds the 70 character "
+                         "width limit and will be\nwrapped\n\nMore content "
+                         "also exceeding 70 characters but will not be "
+                         "wrapped\n\nAdditional long content which will "
+                         "again be wrapped over multiple\nlines")
+
+    def test_readmefile_keep_newlines(self):
+        """
+        ReadmeFile: test preserving newlines
+        """
+        readme = ReadmeFile()
+        self.assertEqual(readme.text(), "")
+        readme.add("Content with newlines which\nwill not be preserved\n")
+        readme.add("These newlines\nwill\nbe preserved", keep_newlines=True)
+        readme.add("These\nwill\nnot")
+        self.assertEqual(readme.text(),
+                         "Content with newlines which will not be "
+                         "preserved\n\nThese newlines\nwill\nbe preserved\n\n"
+                         "These will not")
+
 
 class TestGetRundirInstance(unittest.TestCase):
 


### PR DESCRIPTION
Updates the `ARCHIVE_README` files created by the `archive` command (`make_archive_dir` function) to include information on how to unpack and verify the archive either automatically (using `archiver unpack` command) or manually (using a combination of `tar` and `md5sum` etc).

Also fixes some typos in the generated README files and changes the width of lines in the files to 75 characters (was 70).

There are also updates to the `ReadmeFile` class to facilitate inclusion of unpacking instructions in a "nice" format, and to support arbitrary choices of line width.