### PR TITLE
Fix 'verify_copy' method for CopyArchiveDirectory class

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1429,7 +1429,8 @@ class CopyArchiveDirectory(Directory):
             self.path,
             follow_symlinks=self.replace_symlinks,
             broken_symlinks_placeholders=self.transform_broken_symlinks,
-            ignore_paths=(os.path.basename(self._metadata_dir),
+            ignore_paths=("ARCHIVE_README",
+                          os.path.basename(self._metadata_dir),
                           os.path.basename(self._metadata_dir) + os.sep + "*"))
 
     def __repr__(self):

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -3728,6 +3728,7 @@ class TestCopyArchiveDirectory(unittest.TestCase):
         example_archive.add("subdir1/ex2.txt",type="file",content="example 2")
         example_archive.add("subdir2/ex3.txt",type="file",content="example 3")
         example_archive.add("subdir2/ex4.txt",type="symlink",target="./ex3.txt")
+        example_archive.add("ARCHIVE_README", type="file")
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_METADATA/checksums.md5",type="file",
                             content="""e93b3fa481be3932aa08bd68c3deee70  ex1.txt
@@ -3779,6 +3780,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir2/ex3.txt
         example_archive.add("subdir1/ex2.txt",type="file",content="example 2")
         example_archive.add("subdir2/ex3.txt",type="file",content="example 3")
         example_archive.add("subdir2/ex4.txt",type="file",content="example 3")
+        example_archive.add("ARCHIVE_README", type="file")
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_METADATA/checksums.md5",type="file",
                             content="""e93b3fa481be3932aa08bd68c3deee70  ex1.txt
@@ -3831,6 +3833,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir2/ex4.txt
         example_archive.add("subdir1/ex2.txt",type="file",content="example 2")
         example_archive.add("subdir2/ex3.txt",type="file",content="example 3")
         example_archive.add("subdir3/ex3.txt",type="file",content="example 3")
+        example_archive.add("ARCHIVE_README", type="file")
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_METADATA/checksums.md5",type="file",
                             content="""e93b3fa481be3932aa08bd68c3deee70  ex1.txt
@@ -3883,6 +3886,7 @@ d376eaa7e7aecf81dcbdd6081fae63a9  subdir3/ex3.txt
         example_archive.add("subdir1/ex2.txt",type="file",content="example 2")
         example_archive.add("subdir2/ex3.txt",type="file",content="example 3")
         example_archive.add("subdir2/ex4.txt",type="file",content="missing.txt")
+        example_archive.add("ARCHIVE_README", type="file")
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_METADATA/checksums.md5",type="file",
                             content="""e93b3fa481be3932aa08bd68c3deee70  ex1.txt
@@ -4029,6 +4033,30 @@ class TestGetRundirInstance(unittest.TestCase):
     def test_get_rundir_instance_copy_archive_directory(self):
         """
         get_rundir_instance: returns 'CopyArchiveDirectory' instance
+        """
+        # Build example dir
+        example_dir = UnittestDir(os.path.join(self.wd,"example.archive"))
+        example_dir.add("ARCHIVE_README", type="file")
+        example_dir.add("ARCHIVE_METADATA/checksums.md5",type="file")
+        example_dir.add("ARCHIVE_METADATA/archiver_metadata.json",type="file",
+                        content="""{
+  "name": "example"
+}
+""")
+        example_dir.add("ARCHIVE_METADATA/manifest",type="file")
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.add("subdir1/ex2.txt",type="file")
+        example_dir.add("subdir2/ex3.txt",type="file")
+        example_dir.create()
+        p = example_dir.path
+        p = example_dir.path
+        # Check correct class is returned
+        d = get_rundir_instance(p)
+        self.assertTrue(isinstance(d,CopyArchiveDirectory))
+
+    def test_get_rundir_instance_copy_archive_directory_legacy_no_readme(self):
+        """
+        get_rundir_instance: returns 'CopyArchiveDirectory' instance (legacy/no README)
         """
         # Build example dir
         example_dir = UnittestDir(os.path.join(self.wd,"example.archive"))


### PR DESCRIPTION
Fixes the `verify_copy` method of the `CopyArchiveDirectory` class, to also ignore `ARCHIVE_README` files now produced by the archiver.