### PR TITLE
Add tree file to compressed archive directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -542,7 +542,15 @@ Within a compressed archive directory there will be:
   and a file which lists the original username and group
   associated with each file). If files were excluded
   from the archive (e.g. because they were unreadable)
-  then these will be listed in an additional file.
+  then these will be listed in an additional file;
+- a file called ``ARCHIVE_README`` which provides a
+  human-readable explanation of the archive directory
+  structure and contents, and how to recover the
+  original data;
+- a file called ``ARCHIVE_TREE.txt`` which provides a
+  visual tree representation of the source directory
+  structure (similar to that produced by the Linux
+  ``tree`` command line utility).
 
 The ``.tar.gz`` archives and regular files together
 are sufficient to recover the contents of the original

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2408,6 +2408,28 @@ def make_manifest_file(d, manifest_file, follow_dirlinks=False):
                 rel_path=rel_path))
     return manifest_file
 
+def make_visual_tree_file(d, tree_file):
+    """
+    Create a visual tree file for a directory
+
+    A visual tree lists the directory contents in
+    the same format as the Linux "tree" command
+    line utility.
+
+    Arguments:
+      d (Directory): directory to generate the
+        manifest for
+      tree_file (str): path to the file to
+        write the visual tree to
+    """
+    if Path(tree_file).exists():
+        raise NgsArchiverException(f"{tree_file}: already exists")
+    with open(tree_file, "wt") as fp:
+        fp.write(f"{d.basename}\n")
+        for line in tree(d.path):
+            fp.write(f"{line}\n")
+    return tree_file
+
 def check_make_symlink(d):
     """
     Check if it's possible to make a symbolic link

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1749,6 +1749,9 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
     json_file = os.path.join(ngsarchiver_dir, "archiver_metadata.json")
     with open(json_file,'wt') as fp:
         json.dump(archive_metadata,fp,indent=2)
+    # Add a visual tree file
+    tree_file = os.path.join(temp_archive_dir, "ARCHIVE_TREE.txt")
+    make_visual_tree_file(d, tree_file)
     # Add a README
     readme = ReadmeFile(width=README_LINE_WIDTH)
     readme.add(f"This is a compressed archive of the directory originally "
@@ -1843,7 +1846,10 @@ def make_archive_dir(d,out_dir=None,sub_dirs=None,
                 f"$ cat {d.basename}.archive/*.tar.gz | tar zxvf - -i\n"
                 f"$ md5sum -c {d.basename}.archive/*.md5",
                 indent="    ", wrap=False, keep_newlines=True)
-    readme.add("The ARCHIVE_METADATA subdirectory contains files with "
+    readme.add("The 'ARCHIVE_TREE.txt' file lists the contents of the "
+               "source directory as a text-base tree (similar to the output "
+               "of the Linux 'tree' utility).")
+    readme.add("The 'ARCHIVE_METADATA' subdirectory contains files with "
                "additional metadata about the source files and directories:")
     readme.add("* archive_checksums.md5: MD5 checksums for each of the "
                ".tar.gz and other files in the top-level archive directory, "

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -1395,6 +1395,7 @@ d1ee10b76e42d7e06921e41fbb9b75f7  example/subdir3/ex1.txt
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1520,6 +1521,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1653,6 +1655,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1793,6 +1796,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -1955,6 +1959,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -2144,6 +2149,7 @@ a0b67a19eabb5b96f97a8694e4d8cd9e  miscellaneous.tar.gz
 """)
         example_archive.add("ARCHIVE_METADATA/manifest",type="file")
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -2268,6 +2274,7 @@ a03dcb0295d903ee194ccb117b41f870  example_external_symlinks/subdir3/ex2.txt
 example_external_symlinks/subdir1/symlink1.txt	example_external_symlinks.tar.gz
 """)
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Add an external file
@@ -2425,6 +2432,7 @@ a03dcb0295d903ee194ccb117b41f870  example_broken_symlinks/subdir3/ex2.txt
 example_broken_symlinks/subdir1/symlink1.txt	example_broken_symlinks.tar.gz
 """)
         example_archive.add("ARCHIVE_README",type="file")
+        example_archive.add("ARCHIVE_TREE.txt",type="file")
         example_archive.create()
         p = example_archive.path
         # Expected contents
@@ -4354,6 +4362,8 @@ class TestMakeArchiveDir(unittest.TestCase):
                      "miscellaneous.md5",
                      "ex5.txt",
                      "ex6.txt",
+                     "ARCHIVE_README",
+                     "ARCHIVE_TREE.txt",
                      "ARCHIVE_METADATA",
                      "ARCHIVE_METADATA/archive_checksums.md5",
                      "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4391,6 +4401,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "example.00.md5",
                     "example.01.md5",
                     "ARCHIVE_README",
+                    "ARCHIVE_TREE.txt",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4438,6 +4449,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "subdir2.00.md5",
                     "subdir2.01.md5",
                     "ARCHIVE_README",
+                    "ARCHIVE_TREE.txt",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4495,6 +4507,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "miscellaneous.00.md5",
                     "miscellaneous.01.md5",
                     "ARCHIVE_README",
+                    "ARCHIVE_TREE.txt",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4557,6 +4570,7 @@ class TestMakeArchiveDir(unittest.TestCase):
                     "ex5.txt",
                     "ex6.txt",
                     "ARCHIVE_README",
+                    "ARCHIVE_TREE.txt",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",
@@ -4593,6 +4607,7 @@ class TestMakeArchiveDir(unittest.TestCase):
         expected = ("example.tar.gz",
                     "example.md5",
                     "ARCHIVE_README",
+                    "ARCHIVE_TREE.txt",
                     "ARCHIVE_METADATA",
                     "ARCHIVE_METADATA/archive_checksums.md5",
                     "ARCHIVE_METADATA/archiver_metadata.json",


### PR DESCRIPTION
Updates the `make_archive_dir` function used to create compressed archive directories, to also add a "visual tree" file (named `ARCHIVE_TREE.txt`) to the archive directory.

The visual tree is similar to the output from the Linux `tree` command, for example:

    example
    ├── ex1.txt
    └── subdir
        └── ex2.txt

The visual tree is produced by a new Python function `tree` based on the initial simple example in the StackOverflow answer at https://stackoverflow.com/a/59109706/579925 (with additions to handle symbolic links in a way that mimicks the `tree` command output).