### PR TITLE
'info' command also reports unwriteable files

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -248,13 +248,29 @@ class Directory:
         return True
 
     @property
+    def unwriteable_files(self):
+        """
+        Return full paths to files etc that are not writeable
+        """
+        for o in self.walk():
+            try:
+                if self._cache[o]["unwriteable"]:
+                    yield o
+            except KeyError:
+                if o not in self._cache:
+                    self._cache[o] = {}
+                self._cache[o]["unwriteable"] = (not os.path.islink(o) and
+                                                 not os.access(o,os.W_OK))
+                if self._cache[o]["unwriteable"]:
+                    yield o
+
+    @property
     def is_writeable(self):
         """
         Check if all files and subdirectories are writeable
         """
-        for o in self.walk():
-            if not os.access(o,os.W_OK):
-                return False
+        for o in self.unwriteable_files:
+            return False
         return True
 
     @property

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -219,6 +219,7 @@ def main(argv=None):
                       "Compressed",
                       "Compressed%",
                       "Unreadable?",
+                      "Unwriteable?",
                       "Symlinks?",
                       "Dirlinks?",
                       "External?",
@@ -246,6 +247,7 @@ def main(argv=None):
                         f"{float(compressed_file_size)/float(size)*100.0:.1f}" \
                         if not (compressed_file_size == 0 and size == 0) else "0.0",
                         format_bool(not d.is_readable),
+                        format_bool(not d.is_writeable),
                         format_bool(d.has_symlinks),
                         format_bool(d.has_dirlinks),
                         format_bool(d.has_external_symlinks),
@@ -282,6 +284,13 @@ def main(argv=None):
                     is_readable = False
                 if is_readable:
                     print("-- no unreadable files")
+                print("Unwriteable files:")
+                is_writeable = True
+                for f in d.unwriteable_files:
+                    print(f"-- {f}")
+                    is_writeable = False
+                if is_writeable:
+                    print("-- no unwriteable files")
                 print("Symlinks: %s" % format_bool(d.has_symlinks))
                 print("Dirlinks:")
                 has_dirlinks = False
@@ -335,6 +344,8 @@ def main(argv=None):
             else:
                 print(f"Unreadable files     : "
                       f"{format_bool(not d.is_readable)}")
+                print(f"Unwriteable files    : "
+                      f"{format_bool(not d.is_writeable)}")
                 print(f"Symlinks             : {format_bool(d.has_symlinks)}")
                 print(f"Dirlinks             : {format_bool(d.has_dirlinks)}")
                 print(f"External symlinks    : "

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -581,10 +581,13 @@ class TestDirectory(unittest.TestCase):
         p = example_dir.path
         # Check writability
         d = Directory(p)
+        self.assertEqual(list(d.unwriteable_files),[])
         self.assertTrue(d.is_writeable)
         # Make unwriteable file by stripping permissions
+        d = Directory(p)
         unwriteable_file = os.path.join(p,"ex1.txt")
         os.chmod(unwriteable_file,0o466)
+        self.assertEqual(list(d.unwriteable_files),[unwriteable_file,])
         self.assertFalse(d.is_writeable)
 
     def test_directory_hard_links(self):


### PR DESCRIPTION
Update the `info` command in the CLI to report on "unwriteable" files i.e. files or directories for which the current user doesn't have write permissions.