### PR TITLE
Fix bug in 'unpack' for compressed archives with names not ending in '.archive'

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1238,8 +1238,7 @@ class ArchiveDirectory(Directory):
             raise NgsArchiverException("%s: destination '%s' doesn't "
                                        "exist or is not a directory"
                                        % (self._path,extract_dir))
-        d = os.path.join(extract_dir,
-                         os.path.basename(self._path)[:-len('.archive')])
+        d = os.path.join(extract_dir, self.archive_metadata["name"])
         if os.path.exists(d):
             raise NgsArchiverException("%s: would overwrite existing "
                                        "directory in destination '%s' "


### PR DESCRIPTION
Fixes a bug with the `unpack` method of the `ArchiveDirectory` class, when the compressed archive directory name doesn't end with the standard `.archive` extension (e.g. `example.archive.tmp` rather than `example.archive`).

In these cases an additional empty directory is created in parallel with the expected unpacked directory, with a name generated by dropping the last 7 characters of the archive directory name (e.g. for `example.archive.tmp` it would be `example.arc`).

By extension the bug also affected the `unpack` command (which calls the `unpack` method directly).

The fix prevents the spurious directory being created.