### PR TITLE
Fix archiving of empty top-level subdirectories for multi-subdir & multi-project runs

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -475,6 +475,15 @@ class Directory:
         return False
 
     @property
+    def is_empty(self):
+        """
+        Check if directory is empty
+        """
+        for o in self.walk():
+            return False
+        return True
+
+    @property
     def compressed_files(self):
         """
         Return files that are compressed

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2145,6 +2145,46 @@ def make_archive_multitgz(base_name,root_dir,base_dir=None,
         tgz.close()
     return archive_list
 
+def make_empty_archive(archive_name, root_dir, base_dir=None,
+                       compresslevel=6):
+    """
+    Make a tar.gz archive for an empty directory
+
+    The gzipped tar archive will contain a single entry for
+    "." in the empty directory.
+
+    Raises an exception if the target directory is not empty.
+
+    Arguments:
+      archive_name (str): output archive file name
+        (can include leading path)
+      root_dir (str): path to the directory for which
+        the empty archive will be created
+      base_dir (str): optional path to be prepended to
+        the paths of the archive contents
+      compresslevel (int): optionally specify the
+        gzip compression level (default: 6)
+    """
+    d = Directory(root_dir)
+    if not d.is_empty:
+        raise NgsArchiverException(f"{d.path}: refusing to make empty "
+                                   f"archive for non-empty directory")
+    with tarfile.open(archive_name,'w:gz',
+                      compresslevel=compresslevel) as tgz:
+        arcname = "."
+        if base_dir:
+            arcname = os.path.join(base_dir,arcname)
+        try:
+            tgz.add(d.path,arcname=arcname,recursive=False)
+        except PermissionError as ex:
+            logger.warning(f"{d.path}: unable to add empty top-level "
+                           f"directory to archive: {ex} (ignored)")
+        except Exception as ex:
+            raise NgsArchiverException(f"{d.path}: unable to add "
+                                       f"empty top-level directory "
+                                       f"to archive: {ex}")
+    return archive_name
+
 def unpack_archive_multitgz(archive_list,extract_dir=None):
     """
     Unpack a multi-volume 'gztar' archive

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2031,6 +2031,12 @@ def make_archive_tgz(base_name,root_dir,base_dir=None,ext="tar.gz",
     d = Directory(root_dir)
     archive_name = "%s.%s" % (base_name,ext)
     root_dir = d.path
+    if d.is_empty:
+        # Special case: directory is empty
+        logger.warning(f"{d.path}: creating archive for empty directory")
+        archive_name = "%s.%s" % (base_name, ext)
+        return make_empty_archive(archive_name, root_dir, base_dir=base_dir,
+                                  compresslevel=compresslevel)
     with tarfile.open(archive_name,'w:gz',compresslevel=compresslevel) \
          as tgz:
         for o in d.walk():
@@ -2102,6 +2108,12 @@ def make_archive_multitgz(base_name,root_dir,base_dir=None,
     archive_name = None
     archive_list = []
     tgz = None
+    if d.is_empty:
+        # Special case: directory is empty
+        logger.warning(f"{d.path}: creating archive for empty directory")
+        archive_name = "%s.00.%s" % (base_name, ext)
+        return [make_empty_archive(archive_name, root_dir, base_dir=base_dir,
+                                   compresslevel=compresslevel)]
     for o in d.walk():
         if include_files and o not in include_files:
             continue

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -6204,6 +6204,53 @@ class TestUnpackArchiveMultiTgz(unittest.TestCase):
             self.assertTrue(os.path.relpath(item,self.wd) in all_expected,
                             "'%s' not expected" % item)
 
+    def test_unpack_archive_multitgz_multiple_tar_gz_empty_archive(self):
+        """
+        unpack_archive_multitgz: multiple .tar.gz files including empty archive
+        """
+        # Make example tar.gz files
+        example_targz_data = [
+            { 'path': os.path.join(self.wd,"subdir1.tar.gz"),
+              'b64content': b'H4sIAAAAAAAAA+3T3QqCMBjG8R13FV5BbnO62+gWNAcVRqILdvkpEYRhnfiB9P+dvAd7YS88PC7k17pycXsvynOjYjED2bE27aeyqXyfL0IZY5JuTZlMSKWVtSJK5zhm6N76vIkiUV+Kr3u/3jfKDfJ3Qe998JP+0QecZWY8f60G+SdGd/nLSa8Y8ef5H6r86E63qnRN5F3wu7UPwqI++69W7r959t/Q/yXQfwAAAAAAAAAAAAAAtu8BVJJOSAAoAAA=',
+              'expected': ('example/subdir1',
+                           'example/subdir1/ex1.txt',
+                           'example/subdir1/ex2.txt',),
+            },
+            # "Empty" archive
+            { 'path': os.path.join(self.wd,"subdir2.tar.gz"),
+              'b64content': b'H4sICEcNfWcC/3N1YmRpcjIudGFyAO3PQQqDQAxA0RxlTtBJHMecR6kLpQXRCj1+62JAENqN7v7b/EWySPp3+5wefVzW7j7MVbxFOZ1+ueet5ln3LcRqT15pUycTtdSoScjnn3K0Lq92DkGmsfu5929eHikFAAAAAAAAAAAAAAAAAOBCH1KGpMIAKAAA',
+              'expected': ('example/subdir2',),
+            },
+            { 'path': os.path.join(self.wd,"miscellaneous.tar.gz"),
+              'b64content': b'H4sIAAAAAAAAA+3W0QrCIBQGYK97Cp+gHZ3O1+gVtiZULBqbAx8/V0GxqCjmovZ/N4oOdkD+o9bn+7qyifVi6bxjMVCQZaofhdF0O55JwYRSKiUygjQjISlsc4pSzUDXurzhnNW74ul3r/Z/1KrK13ZzqErbcGe9W3y7IJiUveS/7Ypy26RJjH/0ETdGP84/0TX/Rvb5l2GJ6xjFDM08/8Pzt16Ofg+81f9P55+GOfr/FND/5+0+/+O/Az/JvzTI/xSQfwAAAAAAAAAAAAAAAID/cQRHXCooACgAAA==',
+              'expected': ('example/ex1.txt',
+                           'example/subdir3',
+                           'example/subdir3/ex1.txt',
+                           'example/subdir3/ex2.txt',),
+            }
+        ]
+        for targz in example_targz_data:
+            example_targz = targz['path']
+            with open(example_targz,'wb') as fp:
+                fp.write(base64.b64decode(targz['b64content']))
+        # Unpack the targz files
+        example_targzs = [t['path'] for t in example_targz_data]
+        unpack_archive_multitgz(example_targzs,extract_dir=self.wd)
+        # Check unpacked directories
+        self.assertTrue(os.path.exists(os.path.join(self.wd,"example")))
+        all_expected = []
+        for targz in example_targz_data:
+            expected = targz['expected']
+            for item in expected:
+                self.assertTrue(
+                    os.path.exists(os.path.join(self.wd,item)),
+                    "missing '%s'" % item)
+                all_expected.append(item)
+        # Check extra items aren't present
+        for item in Directory(os.path.join(self.wd,"example")).walk():
+            self.assertTrue(os.path.relpath(item,self.wd) in all_expected,
+                            "'%s' not expected" % item)
+
 class TestMakeCopy(unittest.TestCase):
 
     def setUp(self):

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -683,6 +683,20 @@ class TestDirectory(unittest.TestCase):
                                   os.path.join(p, "subdir1", "ex2.txt"))]))
         self.assertTrue(d.has_case_sensitive_filenames)
 
+    def test_directory_is_empty(self):
+        """
+        Directory: check detection of empty directory
+        """
+        # Build (empty) example dir
+        example_dir = UnittestDir(os.path.join(self.wd,"empty_example"))
+        example_dir.create()
+        self.assertTrue(Directory(example_dir.path).is_empty)
+        # Build non-empty dir
+        example_dir = UnittestDir(os.path.join(self.wd,"example"))
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.create()
+        self.assertFalse(Directory(example_dir.path).is_empty)
+
     def test_directory_check_group(self):
         """
         Directory: check 'check_group' method


### PR DESCRIPTION
Bugfix to archiving of runs with multiple top-level subdirectories, when one or more of the top-level subdirectories is empty.

For example for a run directory with the following:

    run/subdir1/
    run/subdir1/file1.txt
    run/subdir1/file2.txt
    ...
    run/subdir2/

running the `archive` command would either result in no `tar.gz` being generated for empty `run/subdir2/` (if a multi-volume archive was requested), or else the `tar.gz` would be created but would not be a valid archive file. In either case the resulting archive directory could not be used subsequently to fully recreate the original directory.

The fix explicitly detects in either case if a subdirectory is empty, and then creates a valid "empty" `tar.gz` file for it (which can be unpacked to restore the empty subdirectory).

(Technically this bug can also affect multi-project runs, although in practice project directories should never be empty. However the fix would work for this case.)