### PR TITLE
Change spelling of "[un]writeable" to "[un]writable"

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -248,30 +248,44 @@ class Directory:
         return True
 
     @property
-    def unwriteable_files(self):
+    def unwritable_files(self):
         """
-        Return full paths to files etc that are not writeable
+        Return full paths to files etc that are not writable
         """
         for o in self.walk():
             try:
-                if self._cache[o]["unwriteable"]:
+                if self._cache[o]["unwritable"]:
                     yield o
             except KeyError:
                 if o not in self._cache:
                     self._cache[o] = {}
-                self._cache[o]["unwriteable"] = (not os.path.islink(o) and
-                                                 not os.access(o,os.W_OK))
-                if self._cache[o]["unwriteable"]:
+                self._cache[o]["unwritable"] = (not os.path.islink(o) and
+                                                not os.access(o,os.W_OK))
+                if self._cache[o]["unwritable"]:
                     yield o
+
+    @property
+    def unwriteable_files(self):
+        """
+        Wrapper for 'unwritable_files' (for backwards compatibility)
+        """
+        return self.unwritable_files
+
+    @property
+    def is_writable(self):
+        """
+        Check if all files and subdirectories are writable
+        """
+        for o in self.unwritable_files:
+            return False
+        return True
 
     @property
     def is_writeable(self):
         """
-        Check if all files and subdirectories are writeable
+        Wrapper for 'is_writable' (for backwards compatibility)
         """
-        for o in self.unwriteable_files:
-            return False
-        return True
+        return self.is_writable
 
     @property
     def symlinks(self):

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -219,7 +219,7 @@ def main(argv=None):
                       "Compressed",
                       "Compressed%",
                       "Unreadable?",
-                      "Unwriteable?",
+                      "Unwritable?",
                       "Symlinks?",
                       "Dirlinks?",
                       "External?",
@@ -247,7 +247,7 @@ def main(argv=None):
                         f"{float(compressed_file_size)/float(size)*100.0:.1f}" \
                         if not (compressed_file_size == 0 and size == 0) else "0.0",
                         format_bool(not d.is_readable),
-                        format_bool(not d.is_writeable),
+                        format_bool(not d.is_writable),
                         format_bool(d.has_symlinks),
                         format_bool(d.has_dirlinks),
                         format_bool(d.has_external_symlinks),
@@ -284,13 +284,13 @@ def main(argv=None):
                     is_readable = False
                 if is_readable:
                     print("-- no unreadable files")
-                print("Unwriteable files:")
-                is_writeable = True
-                for f in d.unwriteable_files:
+                print("Unwritable files:")
+                is_writable = True
+                for f in d.unwritable_files:
                     print(f"-- {f}")
-                    is_writeable = False
-                if is_writeable:
-                    print("-- no unwriteable files")
+                    is_writable = False
+                if is_writable:
+                    print("-- no unwritable files")
                 print("Symlinks: %s" % format_bool(d.has_symlinks))
                 print("Dirlinks:")
                 has_dirlinks = False
@@ -344,8 +344,8 @@ def main(argv=None):
             else:
                 print(f"Unreadable files     : "
                       f"{format_bool(not d.is_readable)}")
-                print(f"Unwriteable files    : "
-                      f"{format_bool(not d.is_writeable)}")
+                print(f"Unwritable files    : "
+                      f"{format_bool(not d.is_writable)}")
                 print(f"Symlinks             : {format_bool(d.has_symlinks)}")
                 print(f"Dirlinks             : {format_bool(d.has_dirlinks)}")
                 print(f"External symlinks    : "

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -570,9 +570,9 @@ class TestDirectory(unittest.TestCase):
         self.assertEqual(list(d.unreadable_files),[unreadable_file,])
         self.assertFalse(d.is_readable)
 
-    def test_directory_writeability(self):
+    def test_directory_writability(self):
         """
-        Directory: check writeability
+        Directory: check writability
         """
         # Build example dir
         example_dir = UnittestDir(os.path.join(self.wd,"example"))
@@ -582,14 +582,14 @@ class TestDirectory(unittest.TestCase):
         p = example_dir.path
         # Check writability
         d = Directory(p)
-        self.assertEqual(list(d.unwriteable_files),[])
-        self.assertTrue(d.is_writeable)
-        # Make unwriteable file by stripping permissions
+        self.assertEqual(list(d.unwritable_files),[])
+        self.assertTrue(d.is_writable)
+        # Make unwritable file by stripping permissions
         d = Directory(p)
-        unwriteable_file = os.path.join(p,"ex1.txt")
-        os.chmod(unwriteable_file,0o466)
-        self.assertEqual(list(d.unwriteable_files),[unwriteable_file,])
-        self.assertFalse(d.is_writeable)
+        unwritable_file = os.path.join(p,"ex1.txt")
+        os.chmod(unwritable_file,0o466)
+        self.assertEqual(list(d.unwritable_files),[unwritable_file,])
+        self.assertFalse(d.is_writable)
 
     def test_directory_hard_links(self):
         """


### PR DESCRIPTION
Largely cosmetic bug fix/update which addresses the spelling of "[un]writable" in method names, tests, and in the `info` command.