### PR TITLE
'archive' command refuses if source has unreadable content (even with --force)

### DIFF
--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -108,9 +108,9 @@ def main(argv=None):
                                 help="check for and warn about potential "
                                 "issues; don't perform archiving")
     parser_archive.add_argument('--force',action='store_true',
-                                help="ignore issues and perform "
-                                "archiving anyway (may result in "
-                                "incomplete or problematic archive)")
+                                help="ignore issues with links, UIDS and/or "
+                                "archive volume sizes and perform archiving "
+                                "anyway")
 
     # 'copy' command
     parser_copy = s.add_parser('copy',
@@ -398,18 +398,22 @@ def main(argv=None):
         print(f"-- unknown UIDs         : {format_bool(has_unknown_uids)}")
         has_hard_linked_files = d.has_hard_linked_files
         print(f"-- hard linked files    : {format_bool(has_hard_linked_files)}")
+        if not is_readable:
+            msg = "Unreadable files and/or directories detected"
+            logger.critical(msg)
+            if args.check:
+                check_status = 1
+            else:
+                return CLIStatus.ERROR
         if has_external_symlinks or \
            has_broken_symlinks or \
-           not is_readable or \
            has_unknown_uids:
-            msg = "Readability, symlink and/or UID issues detected"
+            msg = "Symlink and/or UID issues detected"
             if args.check:
                 logger.warning(msg)
                 check_status = 1
             elif args.force:
                 msg += " (ignored"
-                if not is_readable:
-                    msg += "; unreadable files will be omitted"
                 if has_external_symlinks or \
                    has_broken_symlinks or \
                    has_unresolvable_symlinks:

--- a/ngsarchiver/test/test_cli.py
+++ b/ngsarchiver/test/test_cli.py
@@ -214,6 +214,27 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(main(['archive',example_dir.path]),
                          CLIStatus.ERROR)
 
+    def test_archive_refuse_if_source_has_unreadable_files(self):
+        """
+        CLI: test the 'archive' command refuses for source with unreadable file (even using --force)
+        """
+        # Make example directory to archive
+        example_dir = UnittestDir(os.path.join(self.wd,"example"))
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.add("subdir1/ex2.txt",type="file")
+        example_dir.create()
+        try:
+            # Make one of the files unreadable
+            os.chmod(os.path.join(example_dir.path, "ex1.txt"), 0o000)
+            # Check archiving refuses
+            self.assertEqual(main(['archive',example_dir.path]),
+                             CLIStatus.ERROR)
+            # Check archiving refuses even with --force
+            self.assertEqual(main(['archive', '--force', example_dir.path]),
+                             CLIStatus.ERROR)
+        finally:
+            os.chmod(os.path.join(example_dir.path, "ex1.txt"), 0o644)
+
     def test_archive_refuse_compressed_archive_directory(self):
         """
         CLI: test the 'archive' command refuses for a compressed archive


### PR DESCRIPTION
Updates the CLI so that the `archive` command now treats any unreadable content in the source directory as an unresolvable error, and will refuse to create a compressed archive in this situation even when the `--force` option is present.