### PR TITLE
Fix unpacking compressed archive when owner doesn't have 'rw' permission on some files/directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -412,15 +412,20 @@ directory with the same name will not be overwritten.
 The restored archive contents are also verified using
 their original checksums as part of the unpacking.
 
-The timestamps and permissions of the contents are
-also restored (with the caveat that all restored
-content will have read-write permission added for the
-user unpacking the archive, regardless of the
-permissions of the original files).
+In addition the timestamps of the unpacked files and
+directories are also restored to those from the source
+directory; by default permissions are not restored,
+instead they be the default permissions for the user
+unpacking the archive (read-write permission will also
+be added). This mimicks the default behaviour of the
+``tar`` utility when unpacking ``.tar.gz`` archives.
 
-Ownership information is not restored (unless the
-archiving and unpacking operations are both performed
-by superuser).
+The ``--copy-permissions`` option can be specified to
+force the permissions to also be restored. Note that
+this can produce undesirable results depending on the
+permissions on the source directory.
+
+Ownership information is not restored.
 
 If only a subset of files need to be restored from
 the archive then the ``extract`` command is recommended

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2214,7 +2214,8 @@ def make_empty_archive(archive_name, root_dir, base_dir=None,
                                        f"to archive: {ex}")
     return archive_name
 
-def unpack_archive_multitgz(archive_list,extract_dir=None):
+def unpack_archive_multitgz(archive_list, extract_dir=None,
+                            set_permissions=False, set_times=False):
     """
     Unpack a multi-volume 'gztar' archive
 
@@ -2223,6 +2224,12 @@ def unpack_archive_multitgz(archive_list,extract_dir=None):
         unpack
       extract_dir (str): specifies directory to unpack
         volumes into (default: current directory)
+      set_permissions (bool): if True then set permissions
+        on extracted files to those from the archive
+        (default: don't set permissions)
+      set_times (bool): if True then set times on extracted
+        files to those from the archive (default: don't set
+        times)
     """
     if extract_dir is None:
         extract_dir = os.getcwd()
@@ -2234,20 +2241,87 @@ def unpack_archive_multitgz(archive_list,extract_dir=None):
         # volumes)
         with tarfile.open(a,'r:gz',errorlevel=1) as tgz:
             for o in tgz:
-                try:
-                    tgz.extract(o,path=extract_dir,set_attrs=False)
-                except Exception as ex:
-                    print("Exception extracting '%s' from '%s': %s"
-                          % (o.name,a,ex))
-                    raise ex
-    atime = time.time()
+                if not o.isdir():
+                    # Extract file without attributes
+                    try:
+                        tgz.extract(o, path=extract_dir, set_attrs=False)
+                    except Exception as ex:
+                        print(f"Exception extracting '{o.name}' from '{a}': "
+                              f"{ex}")
+                        raise ex
+                else:
+                    # Explicitly create directories rather than
+                    # extracting them (workaround for setting
+                    # default permissions)
+                    try:
+                        os.makedirs(os.path.join(extract_dir, o.name))
+                    except Exception as ex:
+                        print(f"Exception creating directory '{o.name}' "
+                              f"from '{a}': {ex}")
+                        raise ex
+    # Set attributes (time and mode) on extracted files
+    set_attributes_from_archive_multitgz(archive_list,
+                                         extract_dir=extract_dir,
+                                         set_permissions=set_permissions,
+                                         set_times=set_times)
+
+def set_attributes_from_archive_multitgz(archive_list, extract_dir=None,
+                                         set_permissions=False,
+                                         set_times=False):
+    """
+    Update permissions and/or times on extracted files
+
+    Arguments:
+      archive_list (list): list of archive volumes to
+        copy attributes from
+      extract_dir (str): specifies directory where unpacked
+        files and directories are (default: current directory)
+      set_permissions (bool): if True then set permissions
+        on extracted files to those from the archive
+        (default: don't set permissions)
+      set_times (bool): if True then set times on extracted
+        files to those from the archive (default: don't set
+        times)
+    """
+    if set_permissions and set_times:
+        attr_types = "permissions and times"
+    elif set_permissions and not set_times:
+        attr_types = "permissions"
+    elif set_times and not set_permissions:
+        attr_types = "times"
+    else:
+        # Nothing to do
+        return
+    if extract_dir is None:
+        extract_dir = os.getcwd()
+    attributes = {}
     for a in archive_list:
-        print("Updating attributes from %s..." % a)
-        with tarfile.open(a,'r:gz',errorlevel=1) as tgz:
-            for o in tgz:
-                o_ = os.path.join(extract_dir,o.name)
-                chmod(o_,o.mode)
-                utime(o_,(atime,o.mtime))
+        print(f"Collecting attributes from {a}...")
+        with tarfile.open(a,'r:gz', errorlevel=1) as tgz:
+            for src in tgz:
+                tgt = os.path.join(extract_dir, src.name)
+                if os.path.islink(tgt):
+                    continue
+                attributes[src.name] = (src.mtime, src.mode)
+    atime = time.time()
+    print(f"Updating {attr_types} on files...")
+    for src in attributes:
+        tgt = os.path.join(extract_dir, src)
+        if not os.path.isdir(tgt):
+            attrs = attributes[src]
+            if set_times:
+                utime(tgt, (atime, attrs[0]))
+            if set_permissions:
+                chmod(tgt, attrs[1])
+    print(f"Updating {attr_types} on directories...")
+    for src in attributes:
+        tgt = os.path.join(extract_dir, src)
+        if os.path.isdir(tgt):
+            attrs = attributes[src]
+            if set_times:
+                utime(tgt, (atime, attrs[0]))
+            if set_permissions:
+                chmod(tgt, attrs[1])
 
 def make_copy(d, dest, replace_symlinks=False,
               transform_broken_symlinks=False,

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -1289,11 +1289,7 @@ class ArchiveDirectory(Directory):
         # Unpack individual archive files
         archive_list = [os.path.join(self._path,a)
                         for a in self._archive_metadata['subarchives']]
-        unpack_archive_multitgz(
-            archive_list,
-            extract_dir,
-            set_permissions=False,
-            set_times=False)
+        unpack_archive_multitgz(archive_list, extract_dir)
         # Do checksum verification on unpacked archive
         if verify:
             print("-- verifying checksums of unpacked files")

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2254,7 +2254,8 @@ def unpack_archive_multitgz(archive_list, extract_dir=None,
                     # extracting them (workaround for setting
                     # default permissions)
                     try:
-                        os.makedirs(os.path.join(extract_dir, o.name))
+                        os.makedirs(os.path.join(extract_dir, o.name),
+                                    exist_ok=True)
                     except Exception as ex:
                         print(f"Exception creating directory '{o.name}' "
                               f"from '{a}': {ex}")

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -162,6 +162,11 @@ def main(argv=None):
                                action='store',dest='out_dir',
                                help="unpack archive under OUT_DIR "
                                "(default: current directory)")
+    parser_unpack.add_argument('--copy-permissions',
+                               action='store_true', dest='copy_permissions',
+                               help="copy the permissions stored in the "
+                               "archive to the extracted files (default: "
+                               "set permissions to read-write)")
 
     # 'search' command
     parser_search = s.add_parser('search',
@@ -558,7 +563,8 @@ def main(argv=None):
                                     "names but destination cannot handle "
                                     "names which only differ by case")
                     return CLIStatus.ERROR
-        d = a.unpack(extract_dir=dest_dir)
+        d = a.unpack(extract_dir=dest_dir,
+                     set_permissions=args.copy_permissions)
         print("Unpacked directory: %s" % d)
         return CLIStatus.OK
 


### PR DESCRIPTION
Fixes an edge case when an compressed archive has been created from a source with some files and/or subdirectories don't have read-write permission for the owner.

It is possible for these archives to be created if the owner is different from the user making the archive. These are valid archives as they can be unpacked and verified directly using the `cp`, `tar` and `md5sum` command line tools, however the `unpack` functionality of the archiver has problems handling them - depending on which files and directories are missing the permissions it may either fail to unpack completely, fail to set permissions from the archive, or fail to verify checksums.

This PR contains a number of updates to the unpacking functions and methods to address this:

* The functionality for setting permissions and timestamps has been extracted from the core `unpack_archive_multitgz` function into a separate function `set_attributes_from_archive_multitgz` (which also allows the invoking function to specify whether to update either one or other of permissions and timestamps, or both together, or neither). By default setting of permissions and timestamps is no longer performed by `unpack_archive_multitgz`.
* The new `set_attributes_from_archive_multitgz` reimplements the setting of attributes so that files are handled in one pass and directories in another (this aims to prevent situations where the permissions could be set to remove read-write on a directory before its contents have been updated).
* The `unpack` method of the `ArchiveDirectory` class now defers setting of attributes until after verification (as neither permissions nor timestamps are checked), so that unreadable files and/or directories don't cause problems.

In addition the default behaviour of the `unpack` functionality has changed so that permissions on the unpacked files and directories are not set from the archive (this is matches the default behaviour of `tar` for non-root users). This required a change to the way that directories are extracted from archives in the `unpack_archive_multitgz` function (to address an apparent inconsistency in how `tarfile.extract()` handles permissions on directories).

A new option `--copy-permissions` has been added to the `unpack` command in the CLI which forces the permissions to be restored from the archived versions (i.e. the behaviour of `unpack` prior to this PR).