### PR TITLE
Fix missing top level directory timestamp and mode data when making archives

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2081,12 +2081,6 @@ def make_archive_tgz(base_name,root_dir,base_dir=None,ext="tar.gz",
     d = Directory(root_dir)
     archive_name = "%s.%s" % (base_name,ext)
     root_dir = d.path
-    if d.is_empty:
-        # Special case: directory is empty
-        logger.warning(f"{d.path}: creating archive for empty directory")
-        archive_name = "%s.%s" % (base_name, ext)
-        return make_empty_archive(archive_name, root_dir, base_dir=base_dir,
-                                  compresslevel=compresslevel)
     with tarfile.open(archive_name,'w:gz',compresslevel=compresslevel) \
          as tgz:
         # Add entry for top-level directory
@@ -2165,12 +2159,6 @@ def make_archive_multitgz(base_name,root_dir,base_dir=None,
     """
     d = Directory(root_dir)
     max_size = convert_size_to_bytes(size)
-    if d.is_empty:
-        # Special case: directory is empty
-        logger.warning(f"{d.path}: creating archive for empty directory")
-        archive_name = "%s.00.%s" % (base_name, ext)
-        return [make_empty_archive(archive_name, root_dir, base_dir=base_dir,
-                                   compresslevel=compresslevel)]
     # Initialise tar archive and add entry for top-level directory
     indx = 0
     archive_name = "%s.%02d.%s" % (base_name, indx, ext)

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -5168,7 +5168,7 @@ class TestMakeArchiveDir(unittest.TestCase):
         with tarfile.open(os.path.join(archive_dir, "subdir2.tar.gz"),
                           "r:gz") as tgz:
             members = tgz.getnames()
-            self.assertEqual(["example/subdir2/."], members)
+            self.assertEqual(["example/subdir2"], members)
         # Check file list
         with open(os.path.join(archive_dir, "ARCHIVE_FILELIST.txt"), "rt") as fp:
             for line in fp:
@@ -5615,7 +5615,7 @@ class TestMakeArchiveDir(unittest.TestCase):
         with tarfile.open(os.path.join(archive_dir, "subdir2.00.tar.gz"),
                           "r:gz") as tgz:
             members = tgz.getnames()
-            self.assertEqual(["example/subdir2/."], members)
+            self.assertEqual(["example/subdir2"], members)
         # Check file list
         with open(os.path.join(archive_dir, "ARCHIVE_FILELIST.txt"), "rt") as fp:
             for line in fp:
@@ -5935,7 +5935,8 @@ class TestMakeArchiveTgz(unittest.TestCase):
         # Check archive exists
         self.assertTrue(os.path.exists(test_archive_path))
         # Check archive contains only expected members
-        expected = set(("ex1.txt",
+        expected = set((".",
+                        "ex1.txt",
                         "subdir",
                         "subdir/ex2.txt",))
         members = set()
@@ -5965,7 +5966,8 @@ class TestMakeArchiveTgz(unittest.TestCase):
         # Check archive exists
         self.assertTrue(os.path.exists(test_archive_path))
         # Check archive contains only expected members
-        expected = set(("example/ex1.txt",
+        expected = set(("example",
+                        "example/ex1.txt",
                         "example/subdir",
                         "example/subdir/ex2.txt",))
         members = set()
@@ -6001,7 +6003,8 @@ class TestMakeArchiveTgz(unittest.TestCase):
         # Check archive exists
         self.assertTrue(os.path.exists(test_archive_path))
         # Check archive contains only expected members
-        expected = set(("ex1.txt",
+        expected = set((".",
+                        "ex1.txt",
                         "subdir",
                         "subdir/ex2.txt",))
         members = set()
@@ -6039,7 +6042,8 @@ class TestMakeArchiveTgz(unittest.TestCase):
         # Check archive exists
         self.assertTrue(os.path.exists(test_archive_path))
         # Check archive contains only expected members
-        expected = set(("ex1.txt",
+        expected = set((".",
+                        "ex1.txt",
                         "subdir",
                         "subdir/ex2.txt",))
         members = set()
@@ -6072,7 +6076,8 @@ class TestMakeArchiveTgz(unittest.TestCase):
         # Check archive exists
         self.assertTrue(os.path.exists(test_archive_path))
         # Check archive contains only expected members
-        expected = set(("ex1.txt",
+        expected = set((".",
+                        "ex1.txt",
                         "subdir",
                         "subdir/ex2.txt",))
         members = set()
@@ -6116,6 +6121,7 @@ class TestMakeArchiveMultiTgz(unittest.TestCase):
                          test_archive_paths)
         # Check archives contains only expected members
         expected = set(example_dir.list())
+        expected.add(".")
         members = set()
         for test_archive_path in test_archive_paths:
             # Check archive exists
@@ -6155,6 +6161,7 @@ class TestMakeArchiveMultiTgz(unittest.TestCase):
                          test_archive_paths)
         # Check archives contains only expected members
         expected = set(example_dir.list(prefix="example"))
+        expected.add("example")
         members = set()
         for test_archive_path in test_archive_paths:
             # Check archive exists
@@ -6201,6 +6208,7 @@ class TestMakeArchiveMultiTgz(unittest.TestCase):
                          test_archive_paths)
         # Check archives contains only expected members
         expected = set(overlay_dir.list())
+        expected.add(".")
         members = set()
         for test_archive_path in test_archive_paths:
             # Check archive exists
@@ -6284,6 +6292,7 @@ class TestMakeArchiveMultiTgz(unittest.TestCase):
                          test_archive_paths)
         # Check archives contains only expected members
         expected = set(example_dir.list())
+        expected.add(".")
         members = set()
         for test_archive_path in test_archive_paths:
             # Check archive exists


### PR DESCRIPTION
Fixes a bug with the timestamps and mode data not being restored when compressed archives are unpacked - essentially these data items were not being stored when the archives were made so can't be recovered.

The fix is to explicitly add an entry for the top-level directory when `tar.gz` archives are generated using the `make_archive_tgz` and `make_archive_multitgz` functions (it also means that empty top-level directories no longer to be treated as a special case).