### PR TITLE
Remove the redundant 'make_empty_archive' function

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2218,46 +2218,6 @@ def make_archive_multitgz(base_name,root_dir,base_dir=None,
         tgz.close()
     return archive_list
 
-def make_empty_archive(archive_name, root_dir, base_dir=None,
-                       compresslevel=6):
-    """
-    Make a tar.gz archive for an empty directory
-
-    The gzipped tar archive will contain a single entry for
-    "." in the empty directory.
-
-    Raises an exception if the target directory is not empty.
-
-    Arguments:
-      archive_name (str): output archive file name
-        (can include leading path)
-      root_dir (str): path to the directory for which
-        the empty archive will be created
-      base_dir (str): optional path to be prepended to
-        the paths of the archive contents
-      compresslevel (int): optionally specify the
-        gzip compression level (default: 6)
-    """
-    d = Directory(root_dir)
-    if not d.is_empty:
-        raise NgsArchiverException(f"{d.path}: refusing to make empty "
-                                   f"archive for non-empty directory")
-    with tarfile.open(archive_name,'w:gz',
-                      compresslevel=compresslevel) as tgz:
-        arcname = "."
-        if base_dir:
-            arcname = os.path.join(base_dir,arcname)
-        try:
-            tgz.add(d.path,arcname=arcname,recursive=False)
-        except PermissionError as ex:
-            logger.warning(f"{d.path}: unable to add empty top-level "
-                           f"directory to archive: {ex} (ignored)")
-        except Exception as ex:
-            raise NgsArchiverException(f"{d.path}: unable to add "
-                                       f"empty top-level directory "
-                                       f"to archive: {ex}")
-    return archive_name
-
 def unpack_archive_multitgz(archive_list, extract_dir=None,
                             set_permissions=False, set_times=False):
     """

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -27,7 +27,6 @@ from ngsarchiver.archive import verify_checksums
 from ngsarchiver.archive import make_archive_dir
 from ngsarchiver.archive import make_archive_tgz
 from ngsarchiver.archive import make_archive_multitgz
-from ngsarchiver.archive import make_empty_archive
 from ngsarchiver.archive import unpack_archive_multitgz
 from ngsarchiver.archive import make_copy
 from ngsarchiver.archive import make_manifest_file
@@ -6306,87 +6305,6 @@ class TestMakeArchiveMultiTgz(unittest.TestCase):
         # Check no expected members are missing from the archive
         for f in expected:
             self.assertTrue(f in members)
-
-class TestMakeEmptyArchive(unittest.TestCase):
-
-    def setUp(self):
-        self.wd = tempfile.mkdtemp(suffix='TestMakeEmptyArchive')
-
-    def tearDown(self):
-        if REMOVE_TEST_OUTPUTS:
-            shutil.rmtree(self.wd)
-
-    def test_make_empty_archive(self):
-        """
-        make_empty_archive: create archive for empty directory
-        """
-        # Build example dir
-        empty_dir = UnittestDir(os.path.join(self.wd, "empty"))
-        empty_dir.create()
-        p = empty_dir.path
-        # Make archive
-        empty_archive = os.path.join(self.wd, "empty.tar.gz")
-        self.assertEqual(make_empty_archive(empty_archive, p),
-                         empty_archive)
-        # Check archive exists
-        self.assertTrue(os.path.exists(empty_archive))
-        # Check archive contains only expected members
-        expected = set(["."])
-        members = set()
-        # Check contents
-        with tarfile.open(empty_archive, "r:gz") as tgz:
-            for f in tgz.getnames():
-                self.assertTrue(f in expected,
-                                f"{f} in archive but shouldn't be")
-                self.assertFalse(f in members, f"{f} appears multiple times")
-                members.add(f)
-        # Check no expected members are missing from the archive
-        for f in expected:
-            self.assertTrue(f in members, f"{f} not found in archive")
-
-    def test_make_empty_archive_with_base_dir(self):
-        """
-        make_empty_archive: empty archive with base directory
-        """
-        # Build example dir
-        empty_dir = UnittestDir(os.path.join(self.wd, "empty"))
-        empty_dir.create()
-        p = empty_dir.path
-        # Make archive
-        empty_archive = os.path.join(self.wd, "empty.tar.gz")
-        self.assertEqual(make_empty_archive(empty_archive, p,
-                                            base_dir="empty"),
-                         empty_archive)
-        # Check archive exists
-        self.assertTrue(os.path.exists(empty_archive))
-        # Check archive contains only expected members
-        expected = set(["empty/."])
-        members = set()
-        # Check contents
-        with tarfile.open(empty_archive, "r:gz") as tgz:
-            for f in tgz.getnames():
-                self.assertTrue(f in expected,
-                                f"{f} in archive but shouldn't be")
-                self.assertFalse(f in members, f"{f} appears multiple times")
-                members.add(f)
-        # Check no expected members are missing from the archive
-        for f in expected:
-            self.assertTrue(f in members, f"{f} not found in archive")
-
-    def test_make_empty_archive_source_dir_not_empty(self):
-        """
-        make_empty_archive: raise exception if source directory isn't empty
-        """
-        # Build example dir
-        non_empty_dir = UnittestDir(os.path.join(self.wd, "not_empty"))
-        non_empty_dir.add("file1.txt", type="file", content="text")
-        non_empty_dir.create()
-        # Attempting to make archive should raise exception
-        non_empty_archive = os.path.join(self.wd, "not_empty.tar.gz")
-        self.assertRaises(NgsArchiverException,
-                          make_empty_archive,
-                          non_empty_archive,
-                          non_empty_dir.path)
 
 class TestUnpackArchiveMultiTgz(unittest.TestCase):
 


### PR DESCRIPTION
PR #70 removes the need for the `make_empty_archive` function, so this PR removes it from the library. 