### PR TITLE
Fix bug in checksum verification for filenames with double spaces

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2031,7 +2031,10 @@ def verify_checksums(md5file,root_dir=None,verbose=False):
     with open(md5file,'rt') as fp:
         for lineno,line in enumerate(fp,start=1):
             try:
-                chksum,path = line.rstrip('\n').split('  ')
+                line = line.rstrip("\n")
+                idx = line.index("  ")
+                chksum = line[:idx]
+                path = line[idx+2:]
                 if verbose:
                     print("-- checking MD5 sum for %s" % path)
                 if root_dir:

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -5879,6 +5879,31 @@ class TestVerifyChecksums(unittest.TestCase):
         # Do verification
         self.assertFalse(verify_checksums(md5file))
 
+    def test_verify_checksums_double_space_in_checksum_line(self):
+        """
+        verify_checksums: handle double space in checksum line
+        """
+        # Build example directory with filename containing
+        # double spaces
+        example_dir = UnittestDir(os.path.join(self.wd,"example"))
+        example_dir.add("ex  1.txt",type="file",content="Example text\n")
+        example_dir.create()
+        p = example_dir.path
+        # Create checksum file
+        checksums = {
+            'ex  1.txt': "8bcc714d327b74a95a166574d0103f5c",
+        }
+        md5file = os.path.join(self.wd,"checksums.txt")
+        with open(md5file,'wt') as fp:
+            for f in checksums:
+                fp.write(
+                    "{checksum}  {path}/{file}\n".format(
+                        path=p,
+                        file=f,
+                        checksum=checksums[f]))
+        # Do verification
+        self.assertTrue(verify_checksums(md5file))
+
     def test_verify_checksums_bad_checksum_line(self):
         """
         verify_checksums: raises exception for 'bad' checksum line


### PR DESCRIPTION
Fixes a  bug in the checksum verification function `verify_checksums` (in the `archive` module) when handling a checksum file entry  for a filename which includes double spaces, for example:

    8bcc714d327b74a95a166574d0103f5c  ex  1.txt

Without the fix the verification function flagged this as a bad line as it wasn't able to parse it correctly.