### PR TITLE
Replace defunct 'ubuntu-20.04' runner for CI tests & update Python versions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,13 +8,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    # Switched from ubuntu-latest to ubuntu-20.04 as former
-    # doesn't support Python 3.6
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -2715,7 +2715,8 @@ d1ee10b76e42d7e06921e41fbb9b75f7  example/subdir3/ex1.txt
         self.assertEqual(os.listdir(self.wd), ["example.archived"])
         a.unpack(extract_dir=self.wd)
         self.assertTrue(os.path.exists(os.path.join(self.wd,"example")))
-        self.assertEqual(os.listdir(self.wd), ["example.archived", "example"])
+        self.assertEqual(sorted(os.listdir(self.wd)),
+                         sorted(["example.archived", "example"]))
         self.assertEqual(os.path.getmtime(os.path.join(self.wd,"example")),
                          os.path.getmtime(a.path))
         for item in expected:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 Setup script to install ngsarchiver package
 
-Copyright (C) University of Manchester 2023 Peter Briggs
+Copyright (C) University of Manchester 2023-2025 Peter Briggs
 
 """
 
@@ -47,9 +47,10 @@ setup(name = "ngsarchiver",
           "Topic :: Scientific/Engineering",
           "Topic :: Scientific/Engineering :: Bio-Informatics",
           "Programming Language :: Python :: 3",
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
       ],
       include_package_data=True,
       zip_safe = False)


### PR DESCRIPTION
Updates the workflow for the CI testing via GitHub Actions, to replace the ubuntu-20.04 hosted runner (which closes down in April 2025) with the ubuntu-24.04 runner.

As Python 3.6 and 3.7 are not available for the newer runner, these have been dropped from the CI testing matrix, and version 3.11 has been added.