### PR TITLE
Fix minor messaging issues

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -2361,7 +2361,7 @@ def make_copy(d, dest, replace_symlinks=False,
     temp_copy = dest + ".part"
     if Path(temp_copy).exists():
         raise NgsArchiverException(f"{d}: found existing partial copy "
-                                   "'{temp_copy}' (remove before retrying)")
+                                   f"'{temp_copy}' (remove before retrying)")
     # Do the copy
     os.makedirs(temp_copy)
     print(f"- copying to {temp_copy}...")

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -349,7 +349,7 @@ def main(argv=None):
             else:
                 print(f"Unreadable files     : "
                       f"{format_bool(not d.is_readable)}")
-                print(f"Unwritable files    : "
+                print(f"Unwritable files     : "
                       f"{format_bool(not d.is_writable)}")
                 print(f"Symlinks             : {format_bool(d.has_symlinks)}")
                 print(f"Dirlinks             : {format_bool(d.has_dirlinks)}")


### PR DESCRIPTION
Fixes two minor issues with messages written to `stdout`:

1. In the CLI `info` command, fixes the alignment when reporting the number of unwritable files
2. In the `make_copy` functions, fixes the error message when the temporary target directory already exists