### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -64,8 +64,22 @@ TREE_LAST =   "└── "
 # Classes
 #######################################################################
 
+# Base class to subclass for custom "Path" class
+BasePath = pathlib.Path
+try:
+    # Check for _flavour attribute
+    # Should be present from Python >=3.12 where
+    # "pathlib.Path" can be subclassed directly
+    BasePath._flavour
+except AttributeError:
+    # _flavour attribue is missing
+    # "pathlib.Path" cannot be not directly subclassed
+    # so use trick from https://stackoverflow.com/a/34116756
+    # to use the parent class instead
+    BasePath = type(pathlib.Path())
 
-class Path(type(pathlib.Path())):
+
+class Path(BasePath):
     """
     Wrapper for pathlib.Path class with additional methods
 
@@ -85,7 +99,12 @@ class Path(type(pathlib.Path())):
     """
 
     def __init__(self, *args, **kws):
-        super().__init__()
+        try:
+            # Direct subclass (Python >=3.12)
+            super().__init__(*args, **kws)
+        except TypeError:
+            # Subclass parent (Python <=3.11)
+            super().__init__()
 
     def owner(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(name = "ngsarchiver",
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
       ],
       include_package_data=True,
       zip_safe = False)


### PR DESCRIPTION
Adds support for Python 3.12 while maintaining compatibility with earlier Python versions.

Most significant update is to how subclassing of the `pathlib.Path` is handled - in 3.12 this can be done directly, whereas in earlier versions a workaround is required.

Also adds Python 3.12 to the matrix of versions used in the Github CI testing workflow.

Closes #75