### PR TITLE
Handle special files (e.g. sockets)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -507,10 +507,13 @@ archive to be checked against the original directory
    archiver compare /PATH/TO/DIR1 /PATH/TO/DIR2
 
 The comparison checks for missing and extra files, and
-that files have the same checksums.
+that files have the same checksums. (Note however that
+it doesn't check timestamps, permissions or ownership.)
 
-(Note however that it doesn't check timestamps,
-permissions or ownership.)
+If one or other of the directories being compared
+contain special files (for example, socket files) then
+these can be excluded from the comparison by
+specifying the ``--exclude-special`` option.
 
 -----------------------------------
 Compressed archive directory format
@@ -648,6 +651,9 @@ when creating an archive:
   in the source where the user running the archiving doesn't
   have read access means that those files cannot be included
   in the archive.
+- **Special files**: special files are file-like objects
+  on the file system (such as sockets) which also cannot be
+  included in the archive.
 - **Hard links**: depending on the archiving mode, the
   presence of hard links can result in bloating of the
   archive directory, as the hard linked file may be included

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -515,6 +515,36 @@ class Directory:
         return False
 
     @property
+    def special_files(self):
+        """
+        Return file system objects which are "special files"
+
+        Special files are things like sockets; anything that
+        isn't a regular file, directory or a link is considered
+        to be a special file.
+        """
+        for o in self.walk():
+            try:
+                if self._cache[o]["is_special_file"]:
+                    yield o
+            except KeyError:
+                if o not in self._cache:
+                    self._cache[o] = {}
+                self._cache[o]["is_special_file"] = Path(o).\
+                                                    is_special_file()
+                if self._cache[o]["is_special_file"]:
+                    yield o
+
+    @property
+    def has_special_files(self):
+        """
+        Check if directory contains special files
+        """
+        for o in self.special_files:
+            return True
+        return False
+
+    @property
     def is_empty(self):
         """
         Check if directory is empty

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -709,6 +709,7 @@ class Directory:
 
     def verify_copy(self,d,follow_symlinks=False,
                     broken_symlinks_placeholders=False,
+                    exclude_special_files=False,
                     ignore_paths=None):
         """
         Verify the directory contents against a copy
@@ -749,6 +750,10 @@ class Directory:
         The 'broken_symlink_placeholders' option operates
         independently of the 'follow_symlinks' option.
 
+        If 'exclude_special_files' is set to True then any
+        special files in either the source or target will
+        be excluded from the verification.
+
         Arguments:
           d (str): path to directory to check against
           follow_symlinks (bool): if True then checks are
@@ -774,6 +779,9 @@ class Directory:
                     ignore = True
                     break
             if ignore:
+                continue
+            # Exclude special files
+            if exclude_special_files and Path(o).is_special_file():
                 continue
             # Compare with target
             o_ = os.path.join(d, rel_path)
@@ -835,6 +843,9 @@ class Directory:
                     ignore = True
                     break
             if ignore:
+                continue
+            # Exclude special files
+            if exclude_special_files and Path(o).is_special_file():
                 continue
             # Check also exists in source
             o_ = os.path.join(self._path, rel_path)

--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -171,6 +171,32 @@ class Path(type(pathlib.Path())):
                 return True
         return False
 
+    def is_special_file(self):
+        """
+        Returns True is Path is a special file
+
+        'Special files' are file system objects such as
+        sockets etc.
+
+        Returns False if the path points to a regular
+        file, a directory, or a link. Otherwise it
+        returns True.
+
+        Returns None if the path points to a non-existent
+        file system object.
+        """
+        try:
+            st_mode = os.lstat(self).st_mode
+            for f in (stat.S_ISREG,
+                      stat.S_ISDIR,
+                      stat.S_ISLNK):
+                if bool(f(st_mode)):
+                    # Not a special file
+                    return False
+            return True
+        except FileNotFoundError:
+            return None
+
 
 class Directory:
     """

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -206,6 +206,10 @@ def main(argv=None):
     parser_compare = s.add_parser('compare',
                                   help="check if two directories have the "
                                   "same contents")
+    parser_compare.add_argument('--exclude-special',
+                                action='store_true',
+                                help="excludes special files (e.g. sockets) "
+                                "from the comparison")
     parser_compare.add_argument('dir1',
                                 help="path to first directory")
     parser_compare.add_argument('dir2',
@@ -600,7 +604,10 @@ def main(argv=None):
             logger.error(ex)
             return CLIStatus.ERROR
         print("Comparing %s against %s" % (d1,args.dir2))
-        if d1.verify_copy(args.dir2):
+        if args.exclude_special:
+            print("-- excluding special files from the comparison")
+        if d1.verify_copy(args.dir2,
+                          exclude_special_files=args.exclude_special):
             print("-- ok")
             return CLIStatus.OK
         else:

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -414,6 +414,8 @@ def main(argv=None):
         print(f"-- unknown UIDs         : {format_bool(has_unknown_uids)}")
         has_hard_linked_files = d.has_hard_linked_files
         print(f"-- hard linked files    : {format_bool(has_hard_linked_files)}")
+        has_special_files = d.has_special_files
+        print(f"-- special files        : {format_bool(has_special_files)}")
         if not is_readable:
             msg = "Unreadable files and/or directories detected"
             logger.critical(msg)
@@ -449,6 +451,17 @@ def main(argv=None):
                 logger.warning("%s (ignored; hard-linked files will "
                                "appear multiple times and size of the "
                                "archive may be inflated)" % msg)
+            else:
+                logger.critical(msg)
+                return CLIStatus.ERROR
+        if has_special_files:
+            msg = "Special files detected"
+            if args.check:
+                logger.warning(msg)
+                check_status = 1
+            elif args.force:
+                msg += " (ignored; special files will be excluded)"
+                logger.warning(msg)
             else:
                 logger.critical(msg)
                 return CLIStatus.ERROR

--- a/ngsarchiver/cli.py
+++ b/ngsarchiver/cli.py
@@ -231,6 +231,7 @@ def main(argv=None):
                       "Broken?",
                       "Unresolvable?",
                       "Hardlinks?",
+                      "Special?",
                       "Unknown_uids?",
                       "Case_sensitive?"]
             print("\t".join(header))
@@ -259,6 +260,7 @@ def main(argv=None):
                         format_bool(d.has_broken_symlinks),
                         format_bool(d.has_unresolvable_symlinks),
                         format_bool(d.has_hard_linked_files),
+                        format_bool(d.has_special_files),
                         format_bool(d.has_unknown_uids),
                         format_bool(d.has_case_sensitive_filenames)]
                 print("\t".join([str(x) for x in line]))
@@ -330,6 +332,13 @@ def main(argv=None):
                     has_hard_links = True
                 if not has_hard_links:
                     print("-- no hard linked files")
+                print("Special files:")
+                has_special_files = False
+                for f in d.special_files:
+                    print(f"-- {f}")
+                    has_special_files = True
+                if not has_special_files:
+                    print("-- no special files")
                 print("Unknown UIDs:")
                 has_unknown_uids = False
                 for f in d.unknown_uids:
@@ -361,6 +370,8 @@ def main(argv=None):
                       f"{format_bool(d.has_unresolvable_symlinks)}")
                 print(f"Hard linked files    : "
                       f"{format_bool(d.has_hard_linked_files)}")
+                print(f"Special files        : "
+                      f"{format_bool(d.has_special_files)}")
                 print(f"Unknown UIDs         : "
                       f"{format_bool(d.has_unknown_uids)}")
                 print(f"Case-sensitive files : "

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -694,6 +694,20 @@ class TestDirectory(unittest.TestCase):
                                   os.path.join(p, "subdir1", "ex2.txt"))]))
         self.assertTrue(d.has_case_sensitive_filenames)
 
+    def test_directory_special_files(self):
+        """
+        Directory: detect special files
+        """
+        # Build example dir
+        example_dir = UnittestDir(os.path.join(self.wd,"example1"))
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.add("subdir1/ex1.txt",type="file")
+        example_dir.create()
+        p = example_dir.path
+        d = Directory(p)
+        self.assertEqual(sorted(list(d.special_files)), [])
+        self.assertFalse(d.has_special_files)
+
     def test_directory_is_empty(self):
         """
         Directory: check detection of empty directory

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -153,6 +153,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(f).is_dirlink())
         self.assertFalse(Path(f).is_broken_symlink())
         self.assertFalse(Path(f).is_unresolvable_symlink())
+        self.assertFalse(Path(f).is_special_file())
 
     def test_path_is_directory(self):
         """
@@ -165,6 +166,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(d).is_dirlink())
         self.assertFalse(Path(d).is_broken_symlink())
         self.assertFalse(Path(d).is_unresolvable_symlink())
+        self.assertFalse(Path(d).is_special_file())
 
     def test_path_is_symlink(self):
         """
@@ -180,6 +182,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_broken_symlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
+        self.assertFalse(Path(s).is_special_file())
 
     def test_path_is_dirlink(self):
         """
@@ -194,6 +197,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_hardlink())
         self.assertFalse(Path(s).is_broken_symlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
+        self.assertFalse(Path(s).is_special_file())
 
     def test_path_is_broken_symlink(self):
         """
@@ -206,6 +210,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_hardlink())
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
+        self.assertFalse(Path(s).is_special_file())
 
     def test_path_is_hard_link(self):
         """
@@ -221,6 +226,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(h).is_dirlink())
         self.assertFalse(Path(h).is_broken_symlink())
         self.assertFalse(Path(h).is_unresolvable_symlink())
+        self.assertFalse(Path(h).is_special_file())
 
     def test_path_is_symlink_loop_single_symlink(self):
         """
@@ -233,6 +239,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_hardlink())
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_broken_symlink())
+        self.assertFalse(Path(s).is_special_file())
         # Check unresolvable symlinks don't upset 'is_dir'
         self.assertFalse(Path(s).is_dir())
 
@@ -249,6 +256,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s1).is_hardlink())
         self.assertFalse(Path(s1).is_dirlink())
         self.assertFalse(Path(s1).is_broken_symlink())
+        self.assertFalse(Path(s1).is_special_file())
         # Check unresolvable symlinks don't upset 'is_dir'
         self.assertFalse(Path(s1).is_dir())
 
@@ -265,6 +273,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_hardlink())
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
+        self.assertFalse(Path(s).is_special_file())
 
     def test_path_is_symlink_to_inaccessible_file(self):
         """
@@ -284,6 +293,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_hardlink())
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
+        self.assertFalse(Path(s).is_special_file())
         # Make subdirectory unreadable
         try:
             os.chmod(d, 0o000)
@@ -292,6 +302,7 @@ class TestPath(unittest.TestCase):
             self.assertFalse(Path(s).is_hardlink())
             self.assertFalse(Path(s).is_dirlink())
             self.assertFalse(Path(s).is_unresolvable_symlink())
+            self.assertFalse(Path(s).is_special_file())
         finally:
             os.chmod(d, 0o777)
 


### PR DESCRIPTION
Updates the archiver to handle special files (i.e. file-like objects such as sockets, which cannot be archived).

The updates include:

* Adding functionality to enable detection of special files
* Reporting special files in the `info` command
* Requiring the `--force` option for the `archive` command when archiving a directory which contains special files (as they will be excluded), and adding those files to the list of excluded files
* Adding a new option `--exclude-special` to the `compare` command, to ignore any special files