### PR TITLE
Fix to Path.is_dir() method to handle inaccessible symlinks

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -121,7 +121,8 @@ class Path(type(pathlib.Path())):
         """
         Overrides 'is_dir' method from base class
         """
-        if not self.is_unresolvable_symlink():
+        if not self.is_broken_symlink() and \
+           not self.is_unresolvable_symlink():
             return super().is_dir()
         return False
 

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -294,6 +294,7 @@ class TestPath(unittest.TestCase):
         self.assertFalse(Path(s).is_dirlink())
         self.assertFalse(Path(s).is_unresolvable_symlink())
         self.assertFalse(Path(s).is_special_file())
+        self.assertFalse(Path(s).is_dir())
         # Make subdirectory unreadable
         try:
             os.chmod(d, 0o000)
@@ -303,6 +304,7 @@ class TestPath(unittest.TestCase):
             self.assertFalse(Path(s).is_dirlink())
             self.assertFalse(Path(s).is_unresolvable_symlink())
             self.assertFalse(Path(s).is_special_file())
+            self.assertFalse(Path(s).is_dir())
         finally:
             os.chmod(d, 0o777)
 


### PR DESCRIPTION
Implements a fix to the `is_dir` method of the `Path` class in the `archive` module, so that it can handle symlinks with inaccessible targets (i.e. targets which lie inside directories which the user doesn't have permission to read).

Without this fix the generation of the visual tree file will crash upon encountering such a file (and hence archive creation will also fail).