### PR TITLE
Fix case-sensitive file name detection for unreadable subdirectories

### DIFF
--- a/ngsarchiver/archive.py
+++ b/ngsarchiver/archive.py
@@ -521,9 +521,11 @@ class Directory:
         for f in group_case_sensitive_names(Path(self.path).iterdir()):
             yield f
         for o in self.walk():
-            if not Path(o).is_symlink() and Path(o).is_dir():
-                for f in group_case_sensitive_names(Path(o).iterdir()):
-                    yield f
+            p = Path(o)
+            if not p.is_symlink() and p.is_dir():
+                if os.access(o, os.R_OK):
+                    for f in group_case_sensitive_names(p.iterdir()):
+                        yield f
 
     @property
     def has_case_sensitive_filenames(self):

--- a/ngsarchiver/test/test_archive.py
+++ b/ngsarchiver/test/test_archive.py
@@ -696,6 +696,52 @@ class TestDirectory(unittest.TestCase):
                                   os.path.join(p, "subdir1", "ex2.txt"))]))
         self.assertTrue(d.has_case_sensitive_filenames)
 
+    def test_directory_case_sensitive_filenames_unreadable_subdir(self):
+        """
+        Directory: detect case-sensitive file names (unreadable subdir)
+        """
+        # Build example dir without collisions but with an
+        # unreadable subdir
+        example_dir = UnittestDir(os.path.join(self.wd,"example1"))
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.add("subdir1/ex1.txt",type="file")
+        example_dir.add("subdir1/ex2.txt",type="file")
+        example_dir.add("subdir1/ex1.txt",type="file")
+        example_dir.add("subdir1/ex2.txt",type="file")
+        example_dir.add("subdir2/ex1.txt",type="file")
+        example_dir.add("subdir2/ex2.txt",type="file")
+        example_dir.create()
+        p = example_dir.path
+        try:
+            # Make subdir1 unreadable
+            os.chmod(os.path.join(p, "subdir1"), 0o000)
+            d = Directory(p)
+            self.assertEqual(sorted(list(d.case_sensitive_filenames)), [])
+            self.assertFalse(d.has_case_sensitive_filenames)
+        finally:
+            os.chmod(os.path.join(p, "subdir1"), 0o777)
+        # Build example dir with collisions but with an
+        # unreadable subdir
+        example_dir = UnittestDir(os.path.join(self.wd,"example2"))
+        example_dir.add("ex1.txt",type="file",content="example 1")
+        example_dir.add("subdir1/ex1.txt",type="file")
+        example_dir.add("subdir1/ex2.txt",type="file")
+        example_dir.add("subdir1/Ex2.txt",type="file")
+        example_dir.add("SubDir1/ex1.txt",type="file")
+        example_dir.add("SubDir1/ex2.txt",type="file")
+        example_dir.create()
+        p = example_dir.path
+        try:
+            # Make subdir1 unreadable
+            os.chmod(os.path.join(p, "subdir1"), 0o000)
+            d = Directory(p)
+            self.assertEqual(sorted(list(d.case_sensitive_filenames)),
+                             sorted([(os.path.join(p, "SubDir1"),
+                                      os.path.join(p, "subdir1")),]))
+            self.assertTrue(d.has_case_sensitive_filenames)
+        finally:
+            os.chmod(os.path.join(p, "subdir1"), 0o777)
+
     def test_directory_special_files(self):
         """
         Directory: detect special files


### PR DESCRIPTION
Fixes a bug in the `Path.case_sensitive_filenames` property when the directory structure being examined includes unreadable subdirectories (by skipping unreadable subdirectories).